### PR TITLE
Added BlockHeightService interface to decouple SendTransactionPool fr…

### DIFF
--- a/src/bin/jet.rs
+++ b/src/bin/jet.rs
@@ -274,7 +274,7 @@ async fn run_jet(config: ConfigJet) -> anyhow::Result<()> {
 
     let send_transactions = SendTransactionsPool::new(
         config.send_transaction_service,
-        blockhash_queue.clone(),
+        Arc::new(blockhash_queue.clone()),
         rooted_transactions.clone(),
         quic_tx_sender.clone(),
     )


### PR DESCRIPTION
@Fatima-yo 

I introduce a trait called `BlockHeightService` which allow `SendTransactionPool` to not be tie to any concrete implementation such as gRPC.

To test, you can create a `MockBlockHeight` that implements the `BlockHeightService` and inject it into the `SendTransactionPool::new` .


