### PR TITLE
Refactor use of pubkey list for shield policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
+- Added support for Yellowstone Shield transaction filtering. When enabled via `shield.enabled`, applies access control policies to determine which transactions can be forwarded to leader nodes.
+
 ### Fixes
 
 ## [11.1.3]
@@ -27,8 +29,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
-- Added stake-based max_streams formula when creating QUIC connection in `QuicPool` so max stream per connection is
-derived from current stake weight.
+- Added stake-based max_streams formula when creating QUIC connection in `QuicPool` so max stream per connection is derived from current stake weight.
 - Remove custom max_stream from configuration options, it should stay dynamic and computed based off validator stake.
 
 ## [11.1.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,16 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 
-- Added support for Yellowstone Shield transaction filtering. When enabled via `shield.enabled`, applies access control policies to determine which transactions can be forwarded to leader nodes.
-
 ### Fixes
+
+## [11.2.0]
+
+### Features
+- Added support for Yellowstone Shield transaction filtering. When enabled via `shield.enabled`, applies access control policies to determine which transactions can be forwarded to leader nodes.
+- Changed `RpcSendTransactionConfigWithBlocklist` to `RpcSendTransactionConfigWithForwardingPolicies` and renamed all related fields from `blocklist` to `forwarding_policies` 
+- Updated protocol buffer definition field from `repeated string blocklist_pdas = 4` to `repeated string forwarding_policies = 4` for consistency
+- Added support for base58-encoded public keys in `forwarding_policies` field with automatic validation and filtering of invalid keys
+- Made `forwarding_policies` optional with a default empty vector when not specified in JSON RPC requests
 
 ## [11.1.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Features
 - Added support for Yellowstone Shield transaction filtering. When enabled via `shield.enabled`, applies access control policies to determine which transactions can be forwarded to leader nodes.
-- Changed `RpcSendTransactionConfigWithBlocklist` to `RpcSendTransactionConfigWithForwardingPolicies` and renamed all related fields from `blocklist` to `forwarding_policies` 
+- Changed `RpcSendTransactionConfigWithBlocklist` to `JetRpcSendTransactionConfig` and renamed all related fields from `blocklist` to `forwarding_policies` 
 - Updated protocol buffer definition field from `repeated string blocklist_pdas = 4` to `repeated string forwarding_policies = 4` for consistency
 - Added support for base58-encoded public keys in `forwarding_policies` field with automatic validation and filtering of invalid keys
 - Made `forwarding_policies` optional with a default empty vector when not specified in JSON RPC requests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7219,7 +7219,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-jet"
-version = "11.1.3"
+version = "11.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-jet"
-version = "11.1.3"
+version = "11.2.0"
 authors = ["Triton One"]
 edition = "2021"
 description = "Yellowstone Jet"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ tracing-subscriber = { version = "0.3.1", features = [
 uuid = { version = "1.11.0", features = ["v4", "serde"] }
 yellowstone-grpc-client = "4.1.1"
 yellowstone-grpc-proto = "4.1.1"
-reqwest = "0.12.15"
+reqwest = { version = "0.12.15", features = ["json"] }
 retry = "2.0.0"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Implements the Solana QUIC protocol for sending transactions.
 - Simulation and transaction sanitization support via external RPC
 - Prometheus metrics
 - Dynamic key loading via getIdentity/setIdentity
-- Support for blocklists to block forwarding to specific leaders
+- Support for shield policies to determine eligible leaders for transaction forwarding
 - Support for connecting to Triton's Cascade delivery network
 
 ## Building
@@ -73,10 +73,8 @@ ProtectSystem=full
 WantedBy=multi-user.target
 ```
 
-
 ## Attribution
 
 Created by the greybeards at [Triton One](https://triton.one)
 
 Copyright (C) 2024 Triton One Ltd
-

--- a/config.yml
+++ b/config.yml
@@ -11,11 +11,8 @@ identity:
 
 # Yellowstone shield policy store configuration
 shield:
-  vixen:
-    yellowstone:
-      endpoint: http://127.0.0.1:10000
-      x_token: null
-      timeout: 60
+  # Enabled shield policy store
+  enabled: false
 
 # RPC & gRPC for upstream validator
 upstream:

--- a/config.yml
+++ b/config.yml
@@ -134,13 +134,9 @@ quic:
 #   # Event buffer queue size
 #   queue_size_buffer: 100000
 
-# yellowstone_blocklist:
-#   contract_pubkey: E47XuTVcCMMYZSmeaybv3BMu6hYktvvFgeZkAJbVgmUx
-
 features:
   enabled_features:
     - transaction_payload_v2
 
-
-prometheus: 
+prometheus:
   url: http://127.0.0.1:8429/api/v1/import/prometheus

--- a/proto/jet.proto
+++ b/proto/jet.proto
@@ -11,7 +11,6 @@ service JetGateway {
   rpc Subscribe(stream SubscribeRequest) returns (stream SubscribeResponse);
 }
 
-
 message AuthRequest {
   oneof auth_step {
     GetChallengeRequest begin_auth = 1;
@@ -26,9 +25,7 @@ message AuthResponse {
   }
 }
 
-message GetChallengeRequest {
-  bytes pubkey_to_verify = 1;
-}
+message GetChallengeRequest { bytes pubkey_to_verify = 1; }
 
 message GetChallengeResponse {
   // Challenge to sign
@@ -47,7 +44,6 @@ message AnswerChallengeRequest {
   bytes signature = 3;
 
   bytes nonce = 4;
-
 }
 
 message AnswerChallengeResponse {
@@ -58,17 +54,11 @@ message AnswerChallengeResponse {
 
 message VersionRequest {}
 
-message VersionResponse {
-  string version = 1;
-}
+message VersionResponse { string version = 1; }
 
-message Ping {
-  uint32 id = 1;
-}
+message Ping { uint32 id = 1; }
 
-message Pong {
-  uint32 id = 1;
-}
+message Pong { uint32 id = 1; }
 
 message PublishRequest {
   oneof message {
@@ -80,8 +70,8 @@ message PublishRequest {
 
 message PublishTransaction {
   oneof payload {
-    bytes legacy_payload = 1;  // For backwards compatibility
-    TransactionWrapper new_payload = 2;  // New structured format
+    bytes legacy_payload = 1;           // For backwards compatibility
+    TransactionWrapper new_payload = 2; // New structured format
   }
 }
 
@@ -95,7 +85,7 @@ message TransactionConfig {
   bool skip_preflight = 1;
   bool skip_sanitize = 2;
   optional uint32 max_retries = 3;
-  repeated string blocklist_pdas = 4;
+  repeated string forwarding_policies = 4;
 }
 
 message PublishResponse {
@@ -115,9 +105,7 @@ message SubscribeRequest {
   }
 }
 
-message InitialSubscribeRequest {
-  FeatureFlags features = 1;
-}
+message InitialSubscribeRequest { FeatureFlags features = 1; }
 
 // Feature flags to negotiate capabilities between client and server
 enum Feature {
@@ -131,14 +119,9 @@ enum Feature {
   // Future features flags
 }
 
-message FeatureFlags {
-  repeated Feature supported_features = 1;
-}
+message FeatureFlags { repeated Feature supported_features = 1; }
 
-
-message SubscribeUpdateLimit {
-  uint64 messages_per100ms = 1;
-}
+message SubscribeUpdateLimit { uint64 messages_per100ms = 1; }
 
 message SubscribeResponse {
   oneof message {
@@ -150,7 +133,7 @@ message SubscribeResponse {
 
 message SubscribeTransaction {
   oneof payload {
-    bytes legacy_payload = 1;  // For backwards compatibility
-    TransactionWrapper new_payload = 2;  // New structured format
+    bytes legacy_payload = 1;           // For backwards compatibility
+    TransactionWrapper new_payload = 2; // New structured format
   }
 }

--- a/src/bin/gentx.rs
+++ b/src/bin/gentx.rs
@@ -37,7 +37,7 @@ use {
     },
     tracing::{error, info},
     yellowstone_jet::{
-        payload::{RpcSendTransactionConfigWithForwardingPolicies, TransactionPayload},
+        payload::{JetRpcSendTransactionConfig, TransactionPayload},
         proto::jet::{
             jet_gateway_client::JetGatewayClient, publish_request::Message as PublishMessage,
             PublishRequest, PublishResponse, PublishTransaction,
@@ -186,7 +186,7 @@ impl TransactionSender {
     async fn send(
         &self,
         transaction: VersionedTransaction,
-        config: RpcSendTransactionConfigWithForwardingPolicies,
+        config: JetRpcSendTransactionConfig,
         should_use_legacy_txn: bool,
     ) -> anyhow::Result<Signature> {
         match self {
@@ -315,7 +315,7 @@ async fn main() -> anyhow::Result<()> {
             let signature = transaction.signatures[0];
             info!("generate transaction {signature} with send lamports {lamports}");
 
-           let config = RpcSendTransactionConfigWithForwardingPolicies::new(
+           let config = JetRpcSendTransactionConfig::new(
                 Some(RpcSendTransactionConfig {
                     skip_preflight: true,
                     skip_sanitize: false,

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -36,7 +36,21 @@ use {
 pub struct RpcSendTransactionConfigWithForwardingPolicies {
     #[serde(flatten)]
     pub config: RpcSendTransactionConfig,
+    #[serde(default, deserialize_with = "deserialize_forwarding_policies")]
     pub forwarding_policies: Vec<Pubkey>,
+}
+
+fn deserialize_forwarding_policies<'de, D>(deserializer: D) -> Result<Vec<Pubkey>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let vec: Vec<String> = Vec::deserialize(deserializer)?;
+    let result = vec
+        .into_iter()
+        .filter_map(|s| Pubkey::from_str(&s).ok())
+        .collect();
+
+    Ok(result)
 }
 
 impl RpcSendTransactionConfigWithForwardingPolicies {

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -306,10 +306,7 @@ impl TransactionDecoder {
                 // Legacy format doesn't have forwarding policies, so we pass None
                 Ok((
                     tx,
-                    Some(JetRpcSendTransactionConfig::new(
-                        Some(legacy.config.clone()),
-                        None,
-                    )),
+                    Some(JetRpcSendTransactionConfig::new(Some(legacy.config), None)),
                 ))
             }
             TransactionPayload::New(wrapper) => {
@@ -639,8 +636,8 @@ mod tests {
         // Legacy format doesn't preserve forwarding policies
         if let Some(config) = decoded_config {
             assert_eq!(config.forwarding_policies.len(), 0);
-            assert_eq!(config.config.skip_preflight, true);
-            assert_eq!(config.config.skip_sanitize, true);
+            assert!(config.config.skip_preflight);
+            assert!(config.config.skip_sanitize);
         } else {
             panic!("Decoded config is None");
         }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -25,7 +25,7 @@ use {
     base64::prelude::{Engine, BASE64_STANDARD},
     serde::{Deserialize, Serialize},
     solana_client::rpc_config::RpcSendTransactionConfig,
-    solana_sdk::transaction::VersionedTransaction,
+    solana_sdk::{pubkey::Pubkey, transaction::VersionedTransaction},
     solana_transaction_status::UiTransactionEncoding,
     std::str::FromStr,
     thiserror::Error,
@@ -33,36 +33,27 @@ use {
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcSendTransactionConfigWithBlockList {
+pub struct RpcSendTransactionConfigWithForwardingPolicies {
     #[serde(flatten)]
-    pub config: Option<RpcSendTransactionConfig>,
-    /// base58-encoded pubkeys
-    pub blocklist_pdas: Option<Vec<String>>,
+    pub config: RpcSendTransactionConfig,
+    pub forwarding_policies: Vec<Pubkey>,
 }
 
-impl RpcSendTransactionConfigWithBlockList {
-    /// Converts the optional string-based blocklist_pdas into a Vec<Pubkey>
-    /// Invalid pubkeys are filtered out
-    pub fn blocklist_pubkeys(&self) -> Vec<solana_sdk::pubkey::Pubkey> {
-        match &self.blocklist_pdas {
-            Some(keys) => keys
-                .iter()
-                .filter_map(
-                    |key_str| match solana_sdk::pubkey::Pubkey::from_str(key_str) {
-                        Ok(pubkey) => Some(pubkey),
-                        Err(_) => None,
-                    },
-                )
-                .collect(),
-            None => Vec::new(),
-        }
-    }
+impl RpcSendTransactionConfigWithForwardingPolicies {
+    pub fn new(
+        config: Option<RpcSendTransactionConfig>,
+        forwarding_policies: Option<Vec<String>>,
+    ) -> Self {
+        let config = config.unwrap_or_default();
+        let forwarding_policies = forwarding_policies
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|key| solana_sdk::pubkey::Pubkey::from_str(key).ok())
+            .collect::<Vec<Pubkey>>();
 
-    /// Get a safe reference to config or a default config if None
-    pub fn get_config(&self) -> RpcSendTransactionConfig {
-        match &self.config {
-            Some(config) => *config,
-            None => RpcSendTransactionConfig::default(),
+        Self {
+            config,
+            forwarding_policies,
         }
     }
 }
@@ -105,7 +96,7 @@ impl TransactionPayload {
     /// Creates a payload in either legacy or new format based on use_legacy flag
     pub fn create(
         transaction: &VersionedTransaction,
-        config: RpcSendTransactionConfigWithBlockList,
+        config: RpcSendTransactionConfigWithForwardingPolicies,
         use_legacy: bool,
     ) -> Result<Self, PayloadError> {
         if use_legacy {
@@ -143,16 +134,12 @@ impl TransactionPayload {
     /// Creates a legacy payload from a transaction and configuration
     pub fn to_legacy(
         transaction: &VersionedTransaction,
-        config_with_blocklist: &RpcSendTransactionConfigWithBlockList,
+        config_with_forwarding_policies: &RpcSendTransactionConfigWithForwardingPolicies,
     ) -> Result<Self, PayloadError> {
-        let encoding = match config_with_blocklist
+        let encoding = config_with_forwarding_policies
             .config
-            .as_ref()
-            .and_then(|c| c.encoding)
-        {
-            Some(encoding) => encoding,
-            None => UiTransactionEncoding::Base58,
-        };
+            .encoding
+            .unwrap_or(UiTransactionEncoding::Base58);
 
         match encoding {
             UiTransactionEncoding::Base64 | UiTransactionEncoding::Base58 => (),
@@ -161,14 +148,9 @@ impl TransactionPayload {
 
         let tx_str = Self::encode_transaction(transaction, encoding)?;
 
-        let config = match &config_with_blocklist.config {
-            Some(cfg) => *cfg,
-            None => RpcSendTransactionConfig::default(),
-        };
-
         Ok(Self::Legacy(LegacyPayload {
             transaction: tx_str,
-            config,
+            config: config_with_forwarding_policies.config,
             timestamp: Some(ms_since_epoch()),
         }))
     }
@@ -247,23 +229,22 @@ impl From<Vec<u8>> for SubscribeTransaction {
     }
 }
 
-impl TryFrom<(&VersionedTransaction, RpcSendTransactionConfigWithBlockList)>
-    for TransactionPayload
+impl
+    TryFrom<(
+        &VersionedTransaction,
+        RpcSendTransactionConfigWithForwardingPolicies,
+    )> for TransactionPayload
 {
     type Error = PayloadError;
 
     fn try_from(
-        (transaction, config_with_blocklist): (
+        (transaction, config_with_forwarding_policies): (
             &VersionedTransaction,
-            RpcSendTransactionConfigWithBlockList,
+            RpcSendTransactionConfigWithForwardingPolicies,
         ),
     ) -> Result<Self, Self::Error> {
         // Check encoding first to fail early if it's invalid
-        if let Some(encoding) = config_with_blocklist
-            .config
-            .as_ref()
-            .and_then(|c| c.encoding)
-        {
+        if let Some(encoding) = config_with_forwarding_policies.config.encoding {
             match encoding {
                 UiTransactionEncoding::Base58 | UiTransactionEncoding::Base64 => {}
                 _ => return Err(PayloadError::UnsupportedEncoding),
@@ -272,40 +253,21 @@ impl TryFrom<(&VersionedTransaction, RpcSendTransactionConfigWithBlockList)>
 
         let tx_bytes = bincode::serialize(transaction)?;
 
-        // Get max_retries safely
-        let max_retries = config_with_blocklist
-            .config
-            .as_ref()
-            .and_then(|c| c.max_retries.map(|r| r as u32));
-
-        // Get skip_preflight safely
-        let skip_preflight = config_with_blocklist
-            .config
-            .as_ref()
-            .map(|c| c.skip_preflight)
-            .unwrap_or(false);
-
-        // Get skip_sanitize safely
-        let skip_sanitize = config_with_blocklist
-            .config
-            .as_ref()
-            .map(|c| c.skip_sanitize)
-            .unwrap_or(false);
-
-        // Get blocklist_pdas safely
-        let blocklist_pdas = match &config_with_blocklist.blocklist_pdas {
-            Some(pdas) => pdas.clone(),
-            None => Vec::new(),
-        };
-
-        // Create new payload format with blocklist_pdas supported
+        // Create new payload format with forwarding policies supported
         Ok(Self::New(TransactionWrapper {
             transaction: tx_bytes,
             config: Some(TransactionConfig {
-                max_retries,
-                blocklist_pdas,
-                skip_preflight,
-                skip_sanitize,
+                max_retries: config_with_forwarding_policies
+                    .config
+                    .max_retries
+                    .map(|r| r as u32),
+                forwarding_policies: config_with_forwarding_policies
+                    .forwarding_policies
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect(),
+                skip_preflight: config_with_forwarding_policies.config.skip_preflight,
+                skip_sanitize: config_with_forwarding_policies.config.skip_sanitize,
             }),
             timestamp: Some(ms_since_epoch()),
         }))
@@ -320,16 +282,16 @@ impl TransactionDecoder {
     ) -> Result<
         (
             VersionedTransaction,
-            Option<RpcSendTransactionConfigWithBlockList>,
+            Option<RpcSendTransactionConfigWithForwardingPolicies>,
         ),
         PayloadError,
     > {
         match payload {
             TransactionPayload::Legacy(legacy) => {
-                let encoding = match legacy.config.encoding {
-                    Some(enc) => enc,
-                    None => UiTransactionEncoding::Base58,
-                };
+                let encoding = legacy
+                    .config
+                    .encoding
+                    .unwrap_or(UiTransactionEncoding::Base58);
 
                 let tx_bytes =
                     TransactionPayload::decode_transaction(&legacy.transaction, encoding)?;
@@ -337,10 +299,10 @@ impl TransactionDecoder {
 
                 Ok((
                     tx,
-                    Some(RpcSendTransactionConfigWithBlockList {
-                        config: Some(legacy.config),
-                        blocklist_pdas: None, // Legacy format doesn't have blocklist
-                    }),
+                    Some(RpcSendTransactionConfigWithForwardingPolicies::new(
+                        Some(legacy.config),
+                        None,
+                    )),
                 ))
             }
             TransactionPayload::New(wrapper) => {
@@ -359,19 +321,12 @@ impl TransactionDecoder {
     }
 }
 
-impl TryFrom<&TransactionConfig> for RpcSendTransactionConfigWithBlockList {
+impl TryFrom<&TransactionConfig> for RpcSendTransactionConfigWithForwardingPolicies {
     type Error = PayloadError;
 
     fn try_from(proto_config: &TransactionConfig) -> Result<Self, Self::Error> {
-        // Convert string pubkeys to actual Pubkey objects, ignoring invalid ones
-        let blocklist_pdas = if proto_config.blocklist_pdas.is_empty() {
-            None
-        } else {
-            Some(proto_config.blocklist_pdas.clone())
-        };
-
-        Ok(Self {
-            config: Some(RpcSendTransactionConfig {
+        Ok(RpcSendTransactionConfigWithForwardingPolicies::new(
+            Some(RpcSendTransactionConfig {
                 max_retries: proto_config.max_retries.map(|r| r as usize),
                 skip_preflight: proto_config.skip_preflight,
                 skip_sanitize: proto_config.skip_sanitize,
@@ -379,8 +334,8 @@ impl TryFrom<&TransactionConfig> for RpcSendTransactionConfigWithBlockList {
                 encoding: None,
                 min_context_slot: None,
             }),
-            blocklist_pdas,
-        })
+            Some(proto_config.forwarding_policies.clone()),
+        ))
     }
 }
 
@@ -396,7 +351,7 @@ mod tests {
             transaction: tx_bytes,
             config: Some(TransactionConfig {
                 max_retries: Some(5),
-                blocklist_pdas: vec![],
+                forwarding_policies: vec![],
                 skip_preflight: true,
                 skip_sanitize: true,
             }),
@@ -407,15 +362,15 @@ mod tests {
     #[test]
     fn test_legacy_format() -> Result<(), Box<dyn std::error::Error>> {
         let tx = VersionedTransaction::default();
-        let config = RpcSendTransactionConfigWithBlockList {
-            config: Some(RpcSendTransactionConfig {
+        let config = RpcSendTransactionConfigWithForwardingPolicies::new(
+            Some(RpcSendTransactionConfig {
                 encoding: Some(UiTransactionEncoding::Base58),
                 skip_preflight: true,
                 skip_sanitize: true,
                 ..Default::default()
             }),
-            blocklist_pdas: None,
-        };
+            None,
+        );
 
         let payload = TransactionPayload::try_from((&tx, config.clone()))?;
 
@@ -424,18 +379,12 @@ mod tests {
 
         let (decoded_tx, decoded_config) = TransactionDecoder::decode(&decoded)?;
         assert!(decoded_config.is_some());
-        let config_with_blocklist = decoded_config.unwrap();
+        let config_with_forwarding_policies = decoded_config.unwrap();
 
         assert_eq!(decoded_tx.signatures, tx.signatures);
-        assert!(config_with_blocklist.config.is_some());
-        let decoded_config = config_with_blocklist.config.unwrap();
         assert_eq!(
-            decoded_config.skip_preflight,
-            config
-                .config
-                .as_ref()
-                .map(|c| c.skip_preflight)
-                .unwrap_or_default()
+            config_with_forwarding_policies.config.skip_preflight,
+            config.config.skip_preflight
         );
         Ok(())
     }
@@ -449,7 +398,7 @@ mod tests {
             transaction: tx_bytes,
             config: Some(TransactionConfig {
                 max_retries: Some(5),
-                blocklist_pdas: vec!["test1".to_string()],
+                forwarding_policies: vec!["test1".to_string()],
                 skip_preflight: true,
                 skip_sanitize: true,
             }),
@@ -460,10 +409,8 @@ mod tests {
         let (_, config) = TransactionDecoder::decode(&payload)?;
 
         assert!(config.is_some());
-        let config_with_blocklist = config.unwrap();
-        assert!(config_with_blocklist.config.is_some());
-        let config = config_with_blocklist.config.unwrap();
-        assert_eq!(config.max_retries, Some(5));
+        let config_with_forwarding_policies = config.unwrap();
+        assert_eq!(config_with_forwarding_policies.config.max_retries, Some(5));
         Ok(())
     }
 
@@ -478,12 +425,10 @@ mod tests {
 
         let (decoded_tx, config) = TransactionDecoder::decode(&decoded)?;
         assert!(config.is_some());
-        let config_with_blocklist = config.unwrap();
-        assert!(config_with_blocklist.config.is_some());
-        let config = config_with_blocklist.config.unwrap();
+        let config_with_forwarding_policies = config.unwrap();
 
-        assert_eq!(config.max_retries, Some(5));
-        assert!(config.skip_preflight);
+        assert_eq!(config_with_forwarding_policies.config.max_retries, Some(5));
+        assert!(config_with_forwarding_policies.config.skip_preflight);
         assert_eq!(decoded_tx.signatures, tx.signatures);
         Ok(())
     }
@@ -492,24 +437,21 @@ mod tests {
     fn test_config_conversion() -> Result<(), Box<dyn std::error::Error>> {
         let proto_config = TransactionConfig {
             max_retries: Some(3),
-            blocklist_pdas: vec!["11111111111111111111111111111111".to_string()],
+            forwarding_policies: vec!["11111111111111111111111111111111".to_string()],
             skip_preflight: true,
             skip_sanitize: true,
         };
 
-        let rpc_config_result: Result<RpcSendTransactionConfigWithBlockList, _> =
+        let rpc_config_result: Result<RpcSendTransactionConfigWithForwardingPolicies, _> =
             (&proto_config).try_into();
         let rpc_config = rpc_config_result?;
 
-        assert!(rpc_config.config.is_some());
-        let config = rpc_config.config.unwrap();
-        assert_eq!(config.max_retries, Some(3));
-        assert!(config.skip_preflight);
-        assert_eq!(config.preflight_commitment, None);
-        assert_eq!(config.encoding, None);
-        assert_eq!(config.min_context_slot, None);
-        assert!(rpc_config.blocklist_pdas.is_some());
-        assert_eq!(rpc_config.blocklist_pdas.as_ref().map(|v| v.len()), Some(1));
+        assert_eq!(rpc_config.config.max_retries, Some(3));
+        assert!(rpc_config.config.skip_preflight);
+        assert_eq!(rpc_config.config.preflight_commitment, None);
+        assert_eq!(rpc_config.config.encoding, None);
+        assert_eq!(rpc_config.config.min_context_slot, None);
+        assert_eq!(rpc_config.forwarding_policies.len(), 1); // Forwarding policies are not validated at this stage
         Ok(())
     }
 
@@ -517,7 +459,7 @@ mod tests {
     fn test_config_invalid_pubkey_conversion() -> Result<(), Box<dyn std::error::Error>> {
         let proto_config = TransactionConfig {
             max_retries: Some(3),
-            blocklist_pdas: vec![
+            forwarding_policies: vec![
                 "11111111111111111111111111111111".to_string(), // Valid pubkey
                 "invalid_pubkey".to_string(),                   // Invalid pubkey
             ],
@@ -525,29 +467,27 @@ mod tests {
             skip_sanitize: true,
         };
 
-        let rpc_config_result: Result<RpcSendTransactionConfigWithBlockList, _> =
+        let rpc_config_result: Result<RpcSendTransactionConfigWithForwardingPolicies, _> =
             (&proto_config).try_into();
-        // Now we expect success (we no longer validate pubkeys at this stage)
         assert!(rpc_config_result.is_ok());
 
         let rpc_config = rpc_config_result?;
-        assert!(rpc_config.blocklist_pdas.is_some());
-        assert_eq!(rpc_config.blocklist_pdas.as_ref().map(|v| v.len()), Some(2)); // Both pubkeys are kept
+        assert_eq!(rpc_config.forwarding_policies.len(), 1);
         Ok(())
     }
 
     #[test]
     fn test_transaction_config_sanitize_flags() -> Result<(), Box<dyn std::error::Error>> {
         let tx = VersionedTransaction::default();
-        let config = RpcSendTransactionConfigWithBlockList {
-            config: Some(RpcSendTransactionConfig {
+        let config = RpcSendTransactionConfigWithForwardingPolicies::new(
+            Some(RpcSendTransactionConfig {
                 skip_preflight: true,
                 skip_sanitize: true,
                 encoding: Some(UiTransactionEncoding::Base64),
                 ..Default::default()
             }),
-            blocklist_pdas: None,
-        };
+            None,
+        );
 
         let payload = TransactionPayload::try_from((&tx, config))?;
         let proto_tx = payload.to_proto::<SubscribeTransaction>()?;
@@ -556,19 +496,17 @@ mod tests {
         let (_, decoded_config) = TransactionDecoder::decode(&decoded)?;
 
         assert!(decoded_config.is_some());
-        let config_with_blocklist = decoded_config.unwrap();
-        assert!(config_with_blocklist.config.is_some());
-        let decoded_config = config_with_blocklist.config.unwrap();
-        assert!(decoded_config.skip_preflight);
-        assert!(decoded_config.skip_sanitize);
+        let config_with_forwarding_policies = decoded_config.unwrap();
+        assert!(config_with_forwarding_policies.config.skip_preflight);
+        assert!(config_with_forwarding_policies.config.skip_sanitize);
         Ok(())
     }
 
     #[test]
     fn test_config_preservation_through_conversion() -> Result<(), Box<dyn std::error::Error>> {
         let tx = VersionedTransaction::default();
-        let original_config = RpcSendTransactionConfigWithBlockList {
-            config: Some(RpcSendTransactionConfig {
+        let original_config = RpcSendTransactionConfigWithForwardingPolicies::new(
+            Some(RpcSendTransactionConfig {
                 skip_preflight: true,
                 skip_sanitize: false,
                 max_retries: Some(3),
@@ -576,35 +514,25 @@ mod tests {
                 encoding: Some(UiTransactionEncoding::Base64),
                 min_context_slot: None,
             }),
-            blocklist_pdas: None,
-        };
+            None,
+        );
 
         let payload = TransactionPayload::try_from((&tx, original_config.clone()))?;
         let (_, decoded_config) = TransactionDecoder::decode(&payload)?;
 
         assert!(decoded_config.is_some());
-        let config_with_blocklist = decoded_config.unwrap();
-        assert!(config_with_blocklist.config.is_some());
-        let decoded_config = config_with_blocklist.config.unwrap();
+        let config_with_forwarding_policies = decoded_config.unwrap();
         assert_eq!(
-            decoded_config.max_retries,
-            original_config.config.as_ref().and_then(|c| c.max_retries)
+            config_with_forwarding_policies.config.max_retries,
+            original_config.config.max_retries
         );
         assert_eq!(
-            decoded_config.skip_preflight,
-            original_config
-                .config
-                .as_ref()
-                .map(|c| c.skip_preflight)
-                .unwrap_or_default()
+            config_with_forwarding_policies.config.skip_preflight,
+            original_config.config.skip_preflight
         );
         assert_eq!(
-            decoded_config.skip_sanitize,
-            original_config
-                .config
-                .as_ref()
-                .map(|c| c.skip_sanitize)
-                .unwrap_or_default()
+            config_with_forwarding_policies.config.skip_sanitize,
+            original_config.config.skip_sanitize
         );
         Ok(())
     }
@@ -612,13 +540,13 @@ mod tests {
     #[test]
     fn test_invalid_encoding() {
         let tx = VersionedTransaction::default();
-        let config = RpcSendTransactionConfigWithBlockList {
-            config: Some(RpcSendTransactionConfig {
+        let config = RpcSendTransactionConfigWithForwardingPolicies::new(
+            Some(RpcSendTransactionConfig {
                 encoding: Some(UiTransactionEncoding::JsonParsed),
                 ..Default::default()
             }),
-            blocklist_pdas: None,
-        };
+            None,
+        );
 
         assert!(TransactionPayload::try_from((&tx, config)).is_err());
     }
@@ -627,60 +555,53 @@ mod tests {
     fn test_empty_config_conversion() -> Result<(), Box<dyn std::error::Error>> {
         let proto_config = TransactionConfig {
             max_retries: None,
-            blocklist_pdas: vec![],
+            forwarding_policies: vec![],
             skip_preflight: false,
             skip_sanitize: false,
         };
 
-        let rpc_config_result: Result<RpcSendTransactionConfigWithBlockList, _> =
+        let rpc_config_result: Result<RpcSendTransactionConfigWithForwardingPolicies, _> =
             (&proto_config).try_into();
         let rpc_config = rpc_config_result?;
 
-        assert!(rpc_config.config.is_some());
-        let config = rpc_config.config.unwrap();
-        assert_eq!(config.max_retries, None);
-        assert!(!config.skip_preflight);
-        assert!(!config.skip_sanitize);
-        assert!(rpc_config.blocklist_pdas.is_none());
+        assert_eq!(rpc_config.config.max_retries, None);
+        assert!(!rpc_config.config.skip_preflight);
+        assert!(!rpc_config.config.skip_sanitize);
+        assert_eq!(rpc_config.forwarding_policies.len(), 0);
         Ok(())
     }
 
     #[test]
-    fn test_blocklist_pdas_conversion() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_forwarding_policies_conversion() -> Result<(), Box<dyn std::error::Error>> {
         let tx = VersionedTransaction::default();
-        let config = RpcSendTransactionConfigWithBlockList {
-            config: Some(RpcSendTransactionConfig::default()),
-            blocklist_pdas: Some(vec![
+        let config = RpcSendTransactionConfigWithForwardingPolicies::new(
+            Some(RpcSendTransactionConfig::default()),
+            Some(vec![
                 "11111111111111111111111111111111".to_string(),
                 "22222222222222222222222222222222".to_string(),
             ]),
-        };
+        );
 
         let payload = TransactionPayload::try_from((&tx, config.clone()))?;
         let (_, decoded_config) = TransactionDecoder::decode(&payload)?;
 
         assert!(decoded_config.is_some());
-        let decoded_blocklist = decoded_config.unwrap().blocklist_pdas;
-        assert!(decoded_blocklist.is_some());
-        let blocklist = decoded_blocklist.unwrap();
-        assert_eq!(blocklist.len(), 2);
-        assert_eq!(blocklist[0], "11111111111111111111111111111111");
-        assert_eq!(blocklist[1], "22222222222222222222222222222222");
+        let decoded_forwarding_policies = decoded_config.unwrap().forwarding_policies;
+        assert_eq!(decoded_forwarding_policies.len(), 1); // Forwarding policies are not preserved through decode
         Ok(())
     }
 
     #[test]
-    fn test_blocklist_pubkeys_conversion() -> Result<(), Box<dyn std::error::Error>> {
-        let config = RpcSendTransactionConfigWithBlockList {
-            config: None,
-            blocklist_pdas: Some(vec![
+    fn test_forwarding_policies_pubkeys_conversion() -> Result<(), Box<dyn std::error::Error>> {
+        let config = RpcSendTransactionConfigWithForwardingPolicies::new(
+            None,
+            Some(vec![
                 "11111111111111111111111111111111".to_string(), // Valid pubkey
                 "invalid_pubkey".to_string(),                   // Invalid pubkey
             ]),
-        };
+        );
 
-        let pubkeys = config.blocklist_pubkeys();
-        assert_eq!(pubkeys.len(), 1); // Only the valid pubkey should be included
+        assert_eq!(config.forwarding_policies.len(), 1); // Only valid pubkey is included
 
         Ok(())
     }

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -24,7 +24,7 @@ pub struct QuicClient {
     connection_cache: Arc<ConnectionCache>,
     extra_tpu_forward: Vec<TpuInfo>,
     tx_broadcast_metrics: broadcast::Sender<QuicClientMetric>,
-    policies: Arc<dyn PolicyStoreTrait + Send + Sync + 'static>,
+    shield_policy_store: Arc<dyn PolicyStoreTrait + Send + Sync + 'static>,
 }
 
 impl fmt::Debug for QuicClient {
@@ -178,7 +178,7 @@ impl QuicClient {
         upcoming_leader_schedule: Arc<dyn UpcomingLeaderSchedule + Send + Sync + 'static>,
         config: ConfigQuic,
         connection_cache: Arc<ConnectionCache>,
-        policies: Arc<dyn PolicyStoreTrait + Send + Sync + 'static>,
+        shield_policy_store: Arc<dyn PolicyStoreTrait + Send + Sync + 'static>,
     ) -> Self {
         let extra_tpu_forward = config
             .extra_tpu_forward
@@ -198,7 +198,7 @@ impl QuicClient {
             connection_cache,
             extra_tpu_forward,
             tx_broadcast_metrics: tx,
-            policies,
+            shield_policy_store,
         }
     }
 
@@ -229,7 +229,7 @@ impl QuicClient {
 
         tpus_info.extend(self.extra_tpu_forward.iter().cloned());
 
-        let snapshot = self.policies.snapshot();
+        let snapshot = self.shield_policy_store.snapshot();
 
         let before_policy_check_tpu_infos_count = tpus_info.len();
         let tpus_info: Vec<TpuInfo> = tpus_info
@@ -290,7 +290,7 @@ impl QuicClient {
             .await;
         tpus_info.extend(self.extra_tpu_forward.iter().cloned());
 
-        let snapshot = self.policies.snapshot();
+        let snapshot = self.shield_policy_store.snapshot();
 
         let before_policy_check_tpu_infos_count = tpus_info.len();
         let tpus_info: Vec<TpuInfo> = tpus_info

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -264,7 +264,7 @@ pub mod rpc_admin {
 pub mod rpc_solana_like {
     use {
         crate::{
-            payload::RpcSendTransactionConfigWithBlockList, rpc::invalid_params,
+            payload::RpcSendTransactionConfigWithForwardingPolicies, rpc::invalid_params,
             solana::decode_and_deserialize, transaction_handler::TransactionHandler,
             transactions::SendTransactionsPool,
         },
@@ -289,7 +289,7 @@ pub mod rpc_solana_like {
         async fn send_transaction(
             &self,
             data: String,
-            config: Option<RpcSendTransactionConfigWithBlockList>,
+            config: Option<RpcSendTransactionConfigWithForwardingPolicies>,
         ) -> RpcResult<String>;
     }
 
@@ -306,7 +306,7 @@ pub mod rpc_solana_like {
         pub async fn handle_internal_transaction(
             &self,
             transaction: VersionedTransaction,
-            config: RpcSendTransactionConfigWithBlockList,
+            config: RpcSendTransactionConfigWithForwardingPolicies,
         ) -> RpcResult<String /* Signature */> {
             debug!("handling internal versioned transaction");
 
@@ -334,11 +334,11 @@ pub mod rpc_solana_like {
         async fn send_transaction(
             &self,
             data: String,
-            config_with_blocklist: Option<RpcSendTransactionConfigWithBlockList>,
+            config_with_forwarding_policies: Option<RpcSendTransactionConfigWithForwardingPolicies>,
         ) -> RpcResult<String /* Signature */> {
             debug!("send_transaction rpc request received");
-            let config_with_blocklist = config_with_blocklist.unwrap_or_default();
-            let config = config_with_blocklist.config.unwrap_or_default();
+            let config_with_policies = config_with_forwarding_policies.unwrap_or_default();
+            let config = config_with_policies.config;
 
             let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
 
@@ -349,7 +349,7 @@ pub mod rpc_solana_like {
                     .ok_or_else(|| invalid_params("unsupported encoding"))?,
             )?;
 
-            self.handle_internal_transaction(transaction, config_with_blocklist)
+            self.handle_internal_transaction(transaction, config_with_policies)
                 .await
         }
     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -264,7 +264,7 @@ pub mod rpc_admin {
 pub mod rpc_solana_like {
     use {
         crate::{
-            payload::RpcSendTransactionConfigWithForwardingPolicies, rpc::invalid_params,
+            payload::JetRpcSendTransactionConfig, rpc::invalid_params,
             solana::decode_and_deserialize, transaction_handler::TransactionHandler,
             transactions::SendTransactionsPool,
         },
@@ -289,7 +289,7 @@ pub mod rpc_solana_like {
         async fn send_transaction(
             &self,
             data: String,
-            config: Option<RpcSendTransactionConfigWithForwardingPolicies>,
+            config: Option<JetRpcSendTransactionConfig>,
         ) -> RpcResult<String>;
     }
 
@@ -306,7 +306,7 @@ pub mod rpc_solana_like {
         pub async fn handle_internal_transaction(
             &self,
             transaction: VersionedTransaction,
-            config: RpcSendTransactionConfigWithForwardingPolicies,
+            config: JetRpcSendTransactionConfig,
         ) -> RpcResult<String /* Signature */> {
             debug!("handling internal versioned transaction");
 
@@ -334,7 +334,7 @@ pub mod rpc_solana_like {
         async fn send_transaction(
             &self,
             data: String,
-            config_with_forwarding_policies: Option<RpcSendTransactionConfigWithForwardingPolicies>,
+            config_with_forwarding_policies: Option<JetRpcSendTransactionConfig>,
         ) -> RpcResult<String /* Signature */> {
             debug!("send_transaction rpc request received");
             let config_with_policies = config_with_forwarding_policies.unwrap_or_default();

--- a/src/transaction_handler.rs
+++ b/src/transaction_handler.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        payload::RpcSendTransactionConfigWithForwardingPolicies,
+        payload::JetRpcSendTransactionConfig,
         solana::decode_and_deserialize,
         transactions::{SendTransactionRequest, SendTransactionsPool},
     },
@@ -93,7 +93,7 @@ impl TransactionHandler {
     pub async fn handle_versioned_transaction(
         &self,
         transaction: VersionedTransaction,
-        config_with_forwarding_policies: RpcSendTransactionConfigWithForwardingPolicies,
+        config_with_forwarding_policies: JetRpcSendTransactionConfig,
     ) -> Result<String /* Signature */, TransactionHandlerError> {
         let config = config_with_forwarding_policies.config;
 
@@ -128,7 +128,7 @@ impl TransactionHandler {
     pub async fn handle_transaction(
         &self,
         data: String,
-        config_with_forwarding_policies: Option<RpcSendTransactionConfigWithForwardingPolicies>,
+        config_with_forwarding_policies: Option<JetRpcSendTransactionConfig>,
     ) -> Result<String /* Signature */, TransactionHandlerError> {
         let config_with_forwarding_policies = config_with_forwarding_policies.unwrap_or_default();
         let config = config_with_forwarding_policies.config;

--- a/src/transaction_handler.rs
+++ b/src/transaction_handler.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        payload::RpcSendTransactionConfigWithBlockList,
+        payload::RpcSendTransactionConfigWithForwardingPolicies,
         solana::decode_and_deserialize,
         transactions::{SendTransactionRequest, SendTransactionsPool},
     },
@@ -93,9 +93,9 @@ impl TransactionHandler {
     pub async fn handle_versioned_transaction(
         &self,
         transaction: VersionedTransaction,
-        config_with_blocklist: RpcSendTransactionConfigWithBlockList,
+        config_with_forwarding_policies: RpcSendTransactionConfigWithForwardingPolicies,
     ) -> Result<String /* Signature */, TransactionHandlerError> {
-        let config = config_with_blocklist.config.unwrap_or_default();
+        let config = config_with_forwarding_policies.config;
 
         // Basic sanitize check first
         transaction
@@ -117,7 +117,7 @@ impl TransactionHandler {
             transaction,
             wire_transaction,
             max_retries: config.max_retries,
-            blocklist_pdas: config_with_blocklist.blocklist_pubkeys(),
+            policies: config_with_forwarding_policies.forwarding_policies,
         }) {
             return Err(TransactionHandlerError::SendFailed(error.to_string()));
         }
@@ -128,14 +128,12 @@ impl TransactionHandler {
     pub async fn handle_transaction(
         &self,
         data: String,
-        config_with_blocklist: Option<RpcSendTransactionConfigWithBlockList>,
+        config_with_forwarding_policies: Option<RpcSendTransactionConfigWithForwardingPolicies>,
     ) -> Result<String /* Signature */, TransactionHandlerError> {
-        let config_with_blocklist = config_with_blocklist.unwrap_or_default();
-        let config = config_with_blocklist.config.unwrap_or_default();
+        let config_with_forwarding_policies = config_with_forwarding_policies.unwrap_or_default();
+        let config = config_with_forwarding_policies.config;
 
-        let (wire_transaction, transaction) = self
-            .prepare_transaction(data, config_with_blocklist.config)
-            .await?;
+        let (wire_transaction, transaction) = self.prepare_transaction(data, config).await?;
         let signature = transaction.signatures[0];
 
         if let Err(error) = self.stp.send_transaction(SendTransactionRequest {
@@ -143,7 +141,7 @@ impl TransactionHandler {
             transaction,
             wire_transaction,
             max_retries: config.max_retries,
-            blocklist_pdas: config_with_blocklist.blocklist_pubkeys(),
+            policies: config_with_forwarding_policies.forwarding_policies,
         }) {
             return Err(TransactionHandlerError::SendFailed(error.to_string()));
         }
@@ -154,9 +152,8 @@ impl TransactionHandler {
     async fn prepare_transaction(
         &self,
         data: String,
-        config: Option<RpcSendTransactionConfig>,
+        config: RpcSendTransactionConfig,
     ) -> Result<(Vec<u8>, VersionedTransaction), TransactionHandlerError> {
-        let config = config.unwrap_or_default();
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
 
         let (wire_transaction, transaction) = decode_and_deserialize(

--- a/tests/test_transactions_pool.rs
+++ b/tests/test_transactions_pool.rs
@@ -51,7 +51,7 @@ pub fn create_send_transaction_request(hash: Hash, max_resent: usize) -> SendTra
         signature: tx.signatures[0],
         wire_transaction,
         transaction: tx,
-        blocklist_pdas: vec![],
+        policies: vec![],
     }
 }
 
@@ -140,7 +140,7 @@ impl TxChannel for SpyTxChannel {
     async fn reserve(
         &self,
         _leader_forward_count: usize,
-        _blocklist_keys: Vec<Pubkey>,
+        _policies: Vec<Pubkey>,
     ) -> Option<BoxedTxChannelPermit> {
         let mode = Arc::clone(&self.mode);
         let curr_mode = { mode.lock().unwrap().clone() };
@@ -190,7 +190,7 @@ async fn test_transaction_send_successful_lifecycle() {
         async fn reserve(
             &self,
             _leader_forward_count: usize,
-            _blocklist_keys: Vec<Pubkey>,
+            _policies: Vec<Pubkey>,
         ) -> Option<BoxedTxChannelPermit> {
             let permit = MockTxChannelPermit {
                 tx: self.tx.clone(),
@@ -306,7 +306,7 @@ async fn it_should_flush_pending_tx() {
         async fn reserve(
             &self,
             _leader_forward_count: usize,
-            _blocklist_keys: Vec<Pubkey>,
+            _policies: Vec<Pubkey>,
         ) -> Option<BoxedTxChannelPermit> {
             let calls = Arc::clone(&self.calls);
             let wait = Arc::clone(&self.wait);
@@ -559,7 +559,7 @@ async fn it_should_not_retry_tx_that_become_finalized() {
         async fn reserve(
             &self,
             _leader_forward_count: usize,
-            _blocklist_keys: Vec<Pubkey>,
+            _policies: Vec<Pubkey>,
         ) -> Option<BoxedTxChannelPermit> {
             let permit = MockTxChannelPermit {
                 send_calls: Arc::clone(&self.send_calls),


### PR DESCRIPTION
## Changes
-  Add`JetRpcTransactionConfig` to handle Solana's RpcTransactionConfig + forwarding policies.
- Renaming blocklist_pdas to forwarding_policies.
- Do some name changes from blocklist to policies except for TransactionConfig since backed with proto and needed by cascade router
