### PR TITLE
fix: entry cleanup in stake sorted-map

### DIFF
--- a/apps/jet/src/quic_gateway.rs
+++ b/apps/jet/src/quic_gateway.rs
@@ -896,7 +896,7 @@ impl StakeSortedPeerSet {
             let mut is_entry_empty = false;
             if let Some(peers) = self.sorted_map.get_mut(&old_stake) {
                 peers.remove(peer);
-                is_entry_empty = true;
+                is_entry_empty = peers.is_empty();
             }
 
             if is_entry_empty {


### PR DESCRIPTION
Previous code cleaned up **all** entries for a stake-amount (in the sorted-map) when any one of its peers is removed