### PR TITLE
fix: use native cargo build instead of cargo-zigbuild

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,8 @@ version: 2
 builds:
     - id: jet
       builder: rust
+      # Native Linux build on the Ubuntu runner; avoid cargo-zigbuild.
+      command: build
       binary: jet
       targets:
           - x86_64-unknown-linux-gnu
@@ -18,10 +20,6 @@ builds:
           - --release
           - --package=yellowstone-jet
           - --bin=jet
-      env:
-          - OPENSSL_INCLUDE_DIR=/usr/include
-          - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
-          - CFLAGS_x86_64_unknown_linux_gnu=-isystem /usr/include/x86_64-linux-gnu
 
 archives:
     - id: jet


### PR DESCRIPTION
## Summary

- Add `command: build` to `.goreleaser.yaml` to use native `cargo build` instead of `cargo-zigbuild`
- `cargo-zigbuild` targets an older GLIBC which conflicts with the runner's system `libcrypto.so` (needs `GLIBC_2.33`/`GLIBC_2.34` symbols like `dlopen`, `pthread_once`, `stat`, etc.)
- Same approach as `alpamayo-private` which already uses `command: build`
- Removes the now-unnecessary `OPENSSL_INCLUDE_DIR`/`OPENSSL_LIB_DIR`/`CFLAGS` env vars (the Binaries-ci workflow already sets `CFLAGS_x86_64_unknown_linux_gnu` globally)

## Test plan
- [ ] Merge and re-tag to trigger Binaries-ci build
- [ ] Verify binary is produced successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)