### PR TITLE
feat: add HTTP tx header overrides and avoid raw body copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,21 @@ Jet exposes a lightweight HTTP endpoint for transaction submission alongside the
 POST /api/v1/transactions
 ```
 
+### Query parameters
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `encoding` | `base58`, `base64` | `base58` | Encoding of the text body (ignored for raw bytes) |
+| `response` | `signature`, `none` | `none` | What to return on success |
+
 ### Optional headers
 
-All per-request configuration for this endpoint is carried in headers.
+These headers provide per-request overrides for retry and policy behavior.
 
 | Header | Values | Description |
 |--------|--------|-------------|
-| `x-jet-encoding` | `base58`, `base64` | Encoding of the text body. Ignored for raw bytes |
 | `x-jet-max-retries` | integer | Maximum retry attempts |
 | `x-jet-forwarding-policies` | comma-separated pubkeys | Restrict forwarding to leaders allowed by these policies |
-| `x-jet-response` | `signature`, `none` | What to return on success |
 
 ### Content types
 
@@ -83,28 +88,24 @@ curl -X POST /api/v1/transactions \
   --data-binary @transaction.bin
 
 # Raw bytes with retry/policy overrides in headers, return signature
-curl -X POST /api/v1/transactions \
+curl -X POST '/api/v1/transactions?response=signature' \
   -H 'Content-Type: application/octet-stream' \
   -H 'x-jet-max-retries: 3' \
   -H 'x-jet-forwarding-policies: 11111111111111111111111111111111' \
-  -H 'x-jet-response: signature' \
   --data-binary @transaction.bin
 
 # Base58 (default encoding), return signature
-curl -X POST /api/v1/transactions \
-  -H 'x-jet-response: signature' \
+curl -X POST '/api/v1/transactions?response=signature' \
   -d '<base58-encoded-tx>'
 
 # Base64 with signature
-curl -X POST /api/v1/transactions \
-  -H 'x-jet-encoding: base64' \
-  -H 'x-jet-response: signature' \
+curl -X POST '/api/v1/transactions?encoding=base64&response=signature' \
   -d '<base64-encoded-tx>'
 ```
 
 ### Response
 
-- **Success**: `200 OK` — empty body by default, or transaction signature if `x-jet-response: signature`
+- **Success**: `200 OK` — empty body by default, or transaction signature if `?response=signature`
 - **Error**: `400 Bad Request` — plain text error message
 - **Wrong method**: `405 Method Not Allowed`
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,19 @@ POST /api/v1/transactions
 |-----------|--------|---------|-------------|
 | `encoding` | `base58`, `base64` | `base58` | Encoding of the text body (ignored for raw bytes) |
 | `max_retries` | integer | none | Maximum retry attempts |
+| `forwarding_policies` | comma-separated pubkeys | none | Restrict forwarding to leaders allowed by these policies |
 | `response` | `signature`, `none` | `none` | What to return on success |
+
+### Optional headers
+
+These are mainly useful for `application/octet-stream` clients that want to avoid putting per-request config in the URL.
+
+| Header | Values | Description |
+|--------|--------|-------------|
+| `x-jet-max-retries` | integer | Overrides `max_retries` |
+| `x-jet-forwarding-policies` | comma-separated pubkeys | Overrides `forwarding_policies` |
+
+If both query params and headers are present for the same field, the header value wins.
 
 ### Content types
 
@@ -77,6 +89,13 @@ POST /api/v1/transactions
 # Raw bytes — fastest, no encoding overhead
 curl -X POST /api/v1/transactions \
   -H 'Content-Type: application/octet-stream' \
+  --data-binary @transaction.bin
+
+# Raw bytes with retry/policy overrides in headers, return signature
+curl -X POST '/api/v1/transactions?response=signature' \
+  -H 'Content-Type: application/octet-stream' \
+  -H 'x-jet-max-retries: 3' \
+  -H 'x-jet-forwarding-policies: 11111111111111111111111111111111' \
   --data-binary @transaction.bin
 
 # Base58 (default encoding), return signature

--- a/README.md
+++ b/README.md
@@ -56,25 +56,16 @@ Jet exposes a lightweight HTTP endpoint for transaction submission alongside the
 POST /api/v1/transactions
 ```
 
-### Query parameters
-
-| Parameter | Values | Default | Description |
-|-----------|--------|---------|-------------|
-| `encoding` | `base58`, `base64` | `base58` | Encoding of the text body (ignored for raw bytes) |
-| `max_retries` | integer | none | Maximum retry attempts |
-| `forwarding_policies` | comma-separated pubkeys | none | Restrict forwarding to leaders allowed by these policies |
-| `response` | `signature`, `none` | `none` | What to return on success |
-
 ### Optional headers
 
-These are mainly useful for `application/octet-stream` clients that want to avoid putting per-request config in the URL.
+All per-request configuration for this endpoint is carried in headers.
 
 | Header | Values | Description |
 |--------|--------|-------------|
-| `x-jet-max-retries` | integer | Overrides `max_retries` |
-| `x-jet-forwarding-policies` | comma-separated pubkeys | Overrides `forwarding_policies` |
-
-If both query params and headers are present for the same field, the header value wins.
+| `x-jet-encoding` | `base58`, `base64` | Encoding of the text body. Ignored for raw bytes |
+| `x-jet-max-retries` | integer | Maximum retry attempts |
+| `x-jet-forwarding-policies` | comma-separated pubkeys | Restrict forwarding to leaders allowed by these policies |
+| `x-jet-response` | `signature`, `none` | What to return on success |
 
 ### Content types
 
@@ -92,24 +83,28 @@ curl -X POST /api/v1/transactions \
   --data-binary @transaction.bin
 
 # Raw bytes with retry/policy overrides in headers, return signature
-curl -X POST '/api/v1/transactions?response=signature' \
+curl -X POST /api/v1/transactions \
   -H 'Content-Type: application/octet-stream' \
   -H 'x-jet-max-retries: 3' \
   -H 'x-jet-forwarding-policies: 11111111111111111111111111111111' \
+  -H 'x-jet-response: signature' \
   --data-binary @transaction.bin
 
 # Base58 (default encoding), return signature
-curl -X POST '/api/v1/transactions?response=signature' \
+curl -X POST /api/v1/transactions \
+  -H 'x-jet-response: signature' \
   -d '<base58-encoded-tx>'
 
 # Base64 with signature
-curl -X POST '/api/v1/transactions?encoding=base64&response=signature' \
+curl -X POST /api/v1/transactions \
+  -H 'x-jet-encoding: base64' \
+  -H 'x-jet-response: signature' \
   -d '<base64-encoded-tx>'
 ```
 
 ### Response
 
-- **Success**: `200 OK` — empty body by default, or transaction signature if `?response=signature`
+- **Success**: `200 OK` — empty body by default, or transaction signature if `x-jet-response: signature`
 - **Error**: `400 Bad Request` — plain text error message
 - **Wrong method**: `405 Method Not Allowed`
 

--- a/apps/jet/src/http_tx_handler.rs
+++ b/apps/jet/src/http_tx_handler.rs
@@ -21,10 +21,8 @@ use {
 };
 
 const API_TX_PATH: &str = "/api/v1/transactions";
-const X_JET_ENCODING: &str = "x-jet-encoding";
 const X_JET_MAX_RETRIES: &str = "x-jet-max-retries";
 const X_JET_FORWARDING_POLICIES: &str = "x-jet-forwarding-policies";
-const X_JET_RESPONSE: &str = "x-jet-response";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ResponseMode {
@@ -41,13 +39,55 @@ struct RequestParams {
 }
 
 impl RequestParams {
-    fn parse(headers: &HeaderMap) -> Result<Self, &'static str> {
+    fn parse(query: Option<&str>, headers: &HeaderMap) -> Result<Self, &'static str> {
+        let Some(query) = query else {
+            let mut params = Self {
+                encoding: UiTransactionEncoding::Base58,
+                encoding_explicit: false,
+                max_retries: None,
+                forwarding_policies: vec![],
+                response: ResponseMode::None,
+            };
+            params.apply_headers(headers)?;
+            return Ok(params);
+        };
+
+        let mut encoding = UiTransactionEncoding::Base58;
+        let mut encoding_explicit = false;
+        let mut response = ResponseMode::None;
+
+        for (key, value) in form_urlencoded::parse(query.as_bytes()) {
+            match key.as_ref() {
+                "encoding" => {
+                    encoding_explicit = true;
+                    encoding = match value.as_ref() {
+                        "base64" => UiTransactionEncoding::Base64,
+                        "base58" => UiTransactionEncoding::Base58,
+                        other => {
+                            warn!(encoding = other, "unsupported encoding in HTTP tx request");
+                            return Err("unsupported encoding: must be 'base64' or 'base58'");
+                        }
+                    };
+                }
+                "response" => {
+                    response = match value.as_ref() {
+                        "signature" => ResponseMode::Signature,
+                        "none" => ResponseMode::None,
+                        _ => {
+                            return Err("unsupported response mode: must be 'signature' or 'none'");
+                        }
+                    };
+                }
+                _ => {}
+            }
+        }
+
         let mut params = Self {
-            encoding: UiTransactionEncoding::Base58,
-            encoding_explicit: false,
+            encoding,
+            encoding_explicit,
             max_retries: None,
             forwarding_policies: vec![],
-            response: ResponseMode::None,
+            response,
         };
         params.apply_headers(headers)?;
         Ok(params)
@@ -62,19 +102,6 @@ impl RequestParams {
     }
 
     fn apply_headers(&mut self, headers: &HeaderMap) -> Result<(), &'static str> {
-        if let Some(value) = headers.get(X_JET_ENCODING) {
-            self.encoding_explicit = true;
-            self.encoding = match value.to_str().ok() {
-                Some("base64") => UiTransactionEncoding::Base64,
-                Some("base58") => UiTransactionEncoding::Base58,
-                Some(other) => {
-                    warn!(encoding = other, "unsupported encoding in HTTP tx request");
-                    return Err("unsupported encoding header: must be 'base64' or 'base58'");
-                }
-                None => return Err("invalid x-jet-encoding header: must be valid UTF-8"),
-            };
-        }
-
         if let Some(value) = headers.get(X_JET_MAX_RETRIES) {
             self.max_retries = value.to_str().ok().and_then(|v| v.parse().ok());
         }
@@ -84,17 +111,6 @@ impl RequestParams {
                 .to_str()
                 .map_err(|_| "invalid x-jet-forwarding-policies header: must be valid UTF-8")?;
             self.forwarding_policies = parse_forwarding_policies(value);
-        }
-
-        if let Some(value) = headers.get(X_JET_RESPONSE) {
-            self.response = match value.to_str().ok() {
-                Some("signature") => ResponseMode::Signature,
-                Some("none") => ResponseMode::None,
-                Some(_) => {
-                    return Err("unsupported response header: must be 'signature' or 'none'");
-                }
-                None => return Err("invalid x-jet-response header: must be valid UTF-8"),
-            };
         }
 
         Ok(())
@@ -135,7 +151,7 @@ impl HttpTransactionHandler {
             );
         }
 
-        let params = match RequestParams::parse(req.headers()) {
+        let params = match RequestParams::parse(req.uri().query(), req.headers()) {
             Ok(p) => p,
             Err(msg) => {
                 metrics::http_tx_requests_inc("error", "unknown");
@@ -317,7 +333,7 @@ mod tests {
 
     #[test]
     fn test_parse_defaults() {
-        let p = RequestParams::parse(&HeaderMap::new()).unwrap();
+        let p = RequestParams::parse(None, &HeaderMap::new()).unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base58);
         assert_eq!(p.max_retries, None);
         assert!(p.forwarding_policies.is_empty());
@@ -325,68 +341,68 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_encoding_header_base64() {
-        let p = RequestParams::parse(&headers(&[(X_JET_ENCODING, "base64")])).unwrap();
+    fn test_parse_encoding_base64() {
+        let p = RequestParams::parse(Some("encoding=base64"), &HeaderMap::new()).unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base64);
     }
 
     #[test]
-    fn test_parse_encoding_header_base58() {
-        let p = RequestParams::parse(&headers(&[(X_JET_ENCODING, "base58")])).unwrap();
+    fn test_parse_encoding_base58() {
+        let p = RequestParams::parse(Some("encoding=base58"), &HeaderMap::new()).unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base58);
     }
 
     #[test]
-    fn test_parse_encoding_header_invalid() {
-        assert!(RequestParams::parse(&headers(&[(X_JET_ENCODING, "json")])).is_err());
+    fn test_parse_encoding_invalid() {
+        assert!(RequestParams::parse(Some("encoding=json"), &HeaderMap::new()).is_err());
     }
 
     #[test]
     fn test_parse_multiple_headers() {
-        let p = RequestParams::parse(&headers(&[
-            (X_JET_ENCODING, "base58"),
-            (X_JET_MAX_RETRIES, "3"),
-        ]))
+        let p = RequestParams::parse(
+            Some("encoding=base58"),
+            &headers(&[(X_JET_MAX_RETRIES, "3")]),
+        )
         .unwrap();
+        assert_eq!(p.encoding, UiTransactionEncoding::Base58);
         assert_eq!(p.max_retries, Some(3));
     }
 
     #[test]
     fn test_parse_max_retries_invalid_ignored() {
-        let p = RequestParams::parse(&headers(&[(X_JET_MAX_RETRIES, "abc")])).unwrap();
+        let p = RequestParams::parse(None, &headers(&[(X_JET_MAX_RETRIES, "abc")])).unwrap();
         assert_eq!(p.max_retries, None);
     }
 
     #[test]
     fn test_parse_response_signature() {
-        let p = RequestParams::parse(&headers(&[(X_JET_RESPONSE, "signature")])).unwrap();
+        let p = RequestParams::parse(Some("response=signature"), &HeaderMap::new()).unwrap();
         assert_eq!(p.response, ResponseMode::Signature);
     }
 
     #[test]
     fn test_parse_response_none() {
-        let p = RequestParams::parse(&headers(&[(X_JET_RESPONSE, "none")])).unwrap();
+        let p = RequestParams::parse(Some("response=none"), &HeaderMap::new()).unwrap();
         assert_eq!(p.response, ResponseMode::None);
     }
 
     #[test]
     fn test_parse_response_default_is_none() {
-        let p = RequestParams::parse(&headers(&[(X_JET_ENCODING, "base64")])).unwrap();
+        let p = RequestParams::parse(Some("encoding=base64"), &HeaderMap::new()).unwrap();
         assert_eq!(p.response, ResponseMode::None);
     }
 
     #[test]
     fn test_parse_response_invalid() {
-        assert!(RequestParams::parse(&headers(&[(X_JET_RESPONSE, "full")])).is_err());
+        assert!(RequestParams::parse(Some("response=full"), &HeaderMap::new()).is_err());
     }
 
     #[test]
-    fn test_parse_all_headers() {
-        let p = RequestParams::parse(&headers(&[
-            (X_JET_ENCODING, "base58"),
-            (X_JET_MAX_RETRIES, "5"),
-            (X_JET_RESPONSE, "signature"),
-        ]))
+    fn test_parse_all_params() {
+        let p = RequestParams::parse(
+            Some("encoding=base58&response=signature"),
+            &headers(&[(X_JET_MAX_RETRIES, "5")]),
+        )
         .unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base58);
         assert_eq!(p.max_retries, Some(5));
@@ -395,22 +411,25 @@ mod tests {
 
     #[test]
     fn test_encoding_explicit_flag() {
-        let p = RequestParams::parse(&headers(&[(X_JET_ENCODING, "base64")])).unwrap();
+        let p = RequestParams::parse(Some("encoding=base64"), &HeaderMap::new()).unwrap();
         assert!(p.encoding_explicit);
 
-        let p = RequestParams::parse(&headers(&[(X_JET_MAX_RETRIES, "3")])).unwrap();
+        let p = RequestParams::parse(None, &headers(&[(X_JET_MAX_RETRIES, "3")])).unwrap();
         assert!(!p.encoding_explicit);
 
-        let p = RequestParams::parse(&HeaderMap::new()).unwrap();
+        let p = RequestParams::parse(None, &HeaderMap::new()).unwrap();
         assert!(!p.encoding_explicit);
     }
 
     #[test]
     fn test_parse_forwarding_policies_header() {
-        let p = RequestParams::parse(&headers(&[(
-            X_JET_FORWARDING_POLICIES,
-            "11111111111111111111111111111111,invalid",
-        )]))
+        let p = RequestParams::parse(
+            None,
+            &headers(&[(
+                X_JET_FORWARDING_POLICIES,
+                "11111111111111111111111111111111,invalid",
+            )]),
+        )
         .unwrap();
         assert_eq!(p.forwarding_policies.len(), 1);
     }

--- a/apps/jet/src/http_tx_handler.rs
+++ b/apps/jet/src/http_tx_handler.rs
@@ -21,8 +21,10 @@ use {
 };
 
 const API_TX_PATH: &str = "/api/v1/transactions";
+const X_JET_ENCODING: &str = "x-jet-encoding";
 const X_JET_MAX_RETRIES: &str = "x-jet-max-retries";
 const X_JET_FORWARDING_POLICIES: &str = "x-jet-forwarding-policies";
+const X_JET_RESPONSE: &str = "x-jet-response";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ResponseMode {
@@ -30,7 +32,7 @@ enum ResponseMode {
     Signature,
 }
 
-struct QueryParams {
+struct RequestParams {
     encoding: UiTransactionEncoding,
     encoding_explicit: bool,
     max_retries: Option<usize>,
@@ -38,64 +40,14 @@ struct QueryParams {
     response: ResponseMode,
 }
 
-impl QueryParams {
-    fn parse(query: Option<&str>, headers: &HeaderMap) -> Result<Self, &'static str> {
-        let Some(query) = query else {
-            let mut params = Self {
-                encoding: UiTransactionEncoding::Base58,
-                encoding_explicit: false,
-                max_retries: None,
-                forwarding_policies: vec![],
-                response: ResponseMode::None,
-            };
-            params.apply_headers(headers)?;
-            return Ok(params);
-        };
-
-        let mut encoding = UiTransactionEncoding::Base58;
-        let mut encoding_explicit = false;
-        let mut max_retries = None;
-        let mut forwarding_policies = vec![];
-        let mut response = ResponseMode::None;
-
-        for (key, value) in form_urlencoded::parse(query.as_bytes()) {
-            match key.as_ref() {
-                "encoding" => {
-                    encoding_explicit = true;
-                    encoding = match value.as_ref() {
-                        "base64" => UiTransactionEncoding::Base64,
-                        "base58" => UiTransactionEncoding::Base58,
-                        other => {
-                            warn!(encoding = other, "unsupported encoding in HTTP tx request");
-                            return Err("unsupported encoding: must be 'base64' or 'base58'");
-                        }
-                    };
-                }
-                "max_retries" => {
-                    max_retries = value.parse().ok();
-                }
-                "forwarding_policies" => {
-                    forwarding_policies = parse_forwarding_policies(value.as_ref());
-                }
-                "response" => {
-                    response = match value.as_ref() {
-                        "signature" => ResponseMode::Signature,
-                        "none" => ResponseMode::None,
-                        _ => {
-                            return Err("unsupported response mode: must be 'signature' or 'none'");
-                        }
-                    };
-                }
-                _ => {}
-            }
-        }
-
+impl RequestParams {
+    fn parse(headers: &HeaderMap) -> Result<Self, &'static str> {
         let mut params = Self {
-            encoding,
-            encoding_explicit,
-            max_retries,
-            forwarding_policies,
-            response,
+            encoding: UiTransactionEncoding::Base58,
+            encoding_explicit: false,
+            max_retries: None,
+            forwarding_policies: vec![],
+            response: ResponseMode::None,
         };
         params.apply_headers(headers)?;
         Ok(params)
@@ -110,6 +62,19 @@ impl QueryParams {
     }
 
     fn apply_headers(&mut self, headers: &HeaderMap) -> Result<(), &'static str> {
+        if let Some(value) = headers.get(X_JET_ENCODING) {
+            self.encoding_explicit = true;
+            self.encoding = match value.to_str().ok() {
+                Some("base64") => UiTransactionEncoding::Base64,
+                Some("base58") => UiTransactionEncoding::Base58,
+                Some(other) => {
+                    warn!(encoding = other, "unsupported encoding in HTTP tx request");
+                    return Err("unsupported encoding header: must be 'base64' or 'base58'");
+                }
+                None => return Err("invalid x-jet-encoding header: must be valid UTF-8"),
+            };
+        }
+
         if let Some(value) = headers.get(X_JET_MAX_RETRIES) {
             self.max_retries = value.to_str().ok().and_then(|v| v.parse().ok());
         }
@@ -119,6 +84,17 @@ impl QueryParams {
                 .to_str()
                 .map_err(|_| "invalid x-jet-forwarding-policies header: must be valid UTF-8")?;
             self.forwarding_policies = parse_forwarding_policies(value);
+        }
+
+        if let Some(value) = headers.get(X_JET_RESPONSE) {
+            self.response = match value.to_str().ok() {
+                Some("signature") => ResponseMode::Signature,
+                Some("none") => ResponseMode::None,
+                Some(_) => {
+                    return Err("unsupported response header: must be 'signature' or 'none'");
+                }
+                None => return Err("invalid x-jet-response header: must be valid UTF-8"),
+            };
         }
 
         Ok(())
@@ -159,7 +135,7 @@ impl HttpTransactionHandler {
             );
         }
 
-        let params = match QueryParams::parse(req.uri().query(), req.headers()) {
+        let params = match RequestParams::parse(req.headers()) {
             Ok(p) => p,
             Err(msg) => {
                 metrics::http_tx_requests_inc("error", "unknown");
@@ -341,7 +317,7 @@ mod tests {
 
     #[test]
     fn test_parse_defaults() {
-        let p = QueryParams::parse(None, &HeaderMap::new()).unwrap();
+        let p = RequestParams::parse(&HeaderMap::new()).unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base58);
         assert_eq!(p.max_retries, None);
         assert!(p.forwarding_policies.is_empty());
@@ -349,72 +325,68 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_encoding_base64() {
-        let p = QueryParams::parse(Some("encoding=base64"), &HeaderMap::new()).unwrap();
+    fn test_parse_encoding_header_base64() {
+        let p = RequestParams::parse(&headers(&[(X_JET_ENCODING, "base64")])).unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base64);
     }
 
     #[test]
-    fn test_parse_encoding_base58() {
-        let p = QueryParams::parse(Some("encoding=base58"), &HeaderMap::new()).unwrap();
+    fn test_parse_encoding_header_base58() {
+        let p = RequestParams::parse(&headers(&[(X_JET_ENCODING, "base58")])).unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base58);
     }
 
     #[test]
-    fn test_parse_encoding_invalid() {
-        assert!(QueryParams::parse(Some("encoding=json"), &HeaderMap::new()).is_err());
+    fn test_parse_encoding_header_invalid() {
+        assert!(RequestParams::parse(&headers(&[(X_JET_ENCODING, "json")])).is_err());
     }
 
     #[test]
-    fn test_parse_multiple_params() {
-        let p =
-            QueryParams::parse(Some("encoding=base58&max_retries=3"), &HeaderMap::new()).unwrap();
-        assert_eq!(p.encoding, UiTransactionEncoding::Base58);
+    fn test_parse_multiple_headers() {
+        let p = RequestParams::parse(&headers(&[
+            (X_JET_ENCODING, "base58"),
+            (X_JET_MAX_RETRIES, "3"),
+        ]))
+        .unwrap();
         assert_eq!(p.max_retries, Some(3));
     }
 
     #[test]
-    fn test_parse_unknown_params_ignored() {
-        let p =
-            QueryParams::parse(Some("foo=bar&encoding=base58&baz=1"), &HeaderMap::new()).unwrap();
-        assert_eq!(p.encoding, UiTransactionEncoding::Base58);
-    }
-
-    #[test]
     fn test_parse_max_retries_invalid_ignored() {
-        let p = QueryParams::parse(Some("max_retries=abc"), &HeaderMap::new()).unwrap();
+        let p = RequestParams::parse(&headers(&[(X_JET_MAX_RETRIES, "abc")])).unwrap();
         assert_eq!(p.max_retries, None);
     }
 
     #[test]
     fn test_parse_response_signature() {
-        let p = QueryParams::parse(Some("response=signature"), &HeaderMap::new()).unwrap();
+        let p = RequestParams::parse(&headers(&[(X_JET_RESPONSE, "signature")])).unwrap();
         assert_eq!(p.response, ResponseMode::Signature);
     }
 
     #[test]
     fn test_parse_response_none() {
-        let p = QueryParams::parse(Some("response=none"), &HeaderMap::new()).unwrap();
+        let p = RequestParams::parse(&headers(&[(X_JET_RESPONSE, "none")])).unwrap();
         assert_eq!(p.response, ResponseMode::None);
     }
 
     #[test]
     fn test_parse_response_default_is_none() {
-        let p = QueryParams::parse(Some("encoding=base64"), &HeaderMap::new()).unwrap();
+        let p = RequestParams::parse(&headers(&[(X_JET_ENCODING, "base64")])).unwrap();
         assert_eq!(p.response, ResponseMode::None);
     }
 
     #[test]
     fn test_parse_response_invalid() {
-        assert!(QueryParams::parse(Some("response=full"), &HeaderMap::new()).is_err());
+        assert!(RequestParams::parse(&headers(&[(X_JET_RESPONSE, "full")])).is_err());
     }
 
     #[test]
-    fn test_parse_all_params() {
-        let p = QueryParams::parse(
-            Some("encoding=base58&max_retries=5&response=signature"),
-            &HeaderMap::new(),
-        )
+    fn test_parse_all_headers() {
+        let p = RequestParams::parse(&headers(&[
+            (X_JET_ENCODING, "base58"),
+            (X_JET_MAX_RETRIES, "5"),
+            (X_JET_RESPONSE, "signature"),
+        ]))
         .unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base58);
         assert_eq!(p.max_retries, Some(5));
@@ -423,44 +395,23 @@ mod tests {
 
     #[test]
     fn test_encoding_explicit_flag() {
-        let p = QueryParams::parse(Some("encoding=base64"), &HeaderMap::new()).unwrap();
+        let p = RequestParams::parse(&headers(&[(X_JET_ENCODING, "base64")])).unwrap();
         assert!(p.encoding_explicit);
 
-        let p = QueryParams::parse(Some("max_retries=3"), &HeaderMap::new()).unwrap();
+        let p = RequestParams::parse(&headers(&[(X_JET_MAX_RETRIES, "3")])).unwrap();
         assert!(!p.encoding_explicit);
 
-        let p = QueryParams::parse(None, &HeaderMap::new()).unwrap();
+        let p = RequestParams::parse(&HeaderMap::new()).unwrap();
         assert!(!p.encoding_explicit);
     }
 
     #[test]
-    fn test_parse_forwarding_policies_query() {
-        let p = QueryParams::parse(
-            Some("forwarding_policies=11111111111111111111111111111111,invalid"),
-            &HeaderMap::new(),
-        )
+    fn test_parse_forwarding_policies_header() {
+        let p = RequestParams::parse(&headers(&[(
+            X_JET_FORWARDING_POLICIES,
+            "11111111111111111111111111111111,invalid",
+        )]))
         .unwrap();
         assert_eq!(p.forwarding_policies.len(), 1);
-    }
-
-    #[test]
-    fn test_parse_headers_override_query_values() {
-        let p = QueryParams::parse(
-            Some(
-                "max_retries=3&forwarding_policies=11111111111111111111111111111111&response=signature",
-            ),
-            &headers(&[
-                (X_JET_MAX_RETRIES, "5"),
-                (
-                    X_JET_FORWARDING_POLICIES,
-                    "Stake11111111111111111111111111111111111111,invalid",
-                ),
-            ]),
-        )
-        .unwrap();
-
-        assert_eq!(p.max_retries, Some(5));
-        assert_eq!(p.forwarding_policies.len(), 1);
-        assert_eq!(p.response, ResponseMode::Signature);
     }
 }

--- a/apps/jet/src/http_tx_handler.rs
+++ b/apps/jet/src/http_tx_handler.rs
@@ -3,13 +3,16 @@ use {
         metrics::jet as metrics, payload::JetRpcSendTransactionConfig,
         transaction_handler::TransactionHandler,
     },
+    bytes::Bytes,
     futures::future::{BoxFuture, FutureExt},
-    hyper::{Request, Response, StatusCode},
+    hyper::{HeaderMap, Request, Response, StatusCode},
     jsonrpsee::core::http_helpers::Body,
+    solana_pubkey::Pubkey,
     solana_rpc_client_api::config::RpcSendTransactionConfig,
     solana_transaction_status_client_types::UiTransactionEncoding,
     std::{
         error::Error,
+        str::FromStr,
         task::{Context, Poll},
         time::Instant,
     },
@@ -18,6 +21,8 @@ use {
 };
 
 const API_TX_PATH: &str = "/api/v1/transactions";
+const X_JET_MAX_RETRIES: &str = "x-jet-max-retries";
+const X_JET_FORWARDING_POLICIES: &str = "x-jet-forwarding-policies";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ResponseMode {
@@ -29,23 +34,28 @@ struct QueryParams {
     encoding: UiTransactionEncoding,
     encoding_explicit: bool,
     max_retries: Option<usize>,
+    forwarding_policies: Vec<Pubkey>,
     response: ResponseMode,
 }
 
 impl QueryParams {
-    fn parse(query: Option<&str>) -> Result<Self, &'static str> {
+    fn parse(query: Option<&str>, headers: &HeaderMap) -> Result<Self, &'static str> {
         let Some(query) = query else {
-            return Ok(Self {
+            let mut params = Self {
                 encoding: UiTransactionEncoding::Base58,
                 encoding_explicit: false,
                 max_retries: None,
+                forwarding_policies: vec![],
                 response: ResponseMode::None,
-            });
+            };
+            params.apply_headers(headers)?;
+            return Ok(params);
         };
 
         let mut encoding = UiTransactionEncoding::Base58;
         let mut encoding_explicit = false;
         let mut max_retries = None;
+        let mut forwarding_policies = vec![];
         let mut response = ResponseMode::None;
 
         for (key, value) in form_urlencoded::parse(query.as_bytes()) {
@@ -64,6 +74,9 @@ impl QueryParams {
                 "max_retries" => {
                     max_retries = value.parse().ok();
                 }
+                "forwarding_policies" => {
+                    forwarding_policies = parse_forwarding_policies(value.as_ref());
+                }
                 "response" => {
                     response = match value.as_ref() {
                         "signature" => ResponseMode::Signature,
@@ -77,12 +90,15 @@ impl QueryParams {
             }
         }
 
-        Ok(Self {
+        let mut params = Self {
             encoding,
             encoding_explicit,
             max_retries,
+            forwarding_policies,
             response,
-        })
+        };
+        params.apply_headers(headers)?;
+        Ok(params)
     }
 
     const fn encoding_label(&self) -> &'static str {
@@ -92,6 +108,30 @@ impl QueryParams {
             _ => "unknown",
         }
     }
+
+    fn apply_headers(&mut self, headers: &HeaderMap) -> Result<(), &'static str> {
+        if let Some(value) = headers.get(X_JET_MAX_RETRIES) {
+            self.max_retries = value.to_str().ok().and_then(|v| v.parse().ok());
+        }
+
+        if let Some(value) = headers.get(X_JET_FORWARDING_POLICIES) {
+            let value = value
+                .to_str()
+                .map_err(|_| "invalid x-jet-forwarding-policies header: must be valid UTF-8")?;
+            self.forwarding_policies = parse_forwarding_policies(value);
+        }
+
+        Ok(())
+    }
+}
+
+fn parse_forwarding_policies(value: &str) -> Vec<Pubkey> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .filter_map(|v| Pubkey::from_str(v).ok())
+        .collect()
 }
 
 #[derive(Clone)]
@@ -119,7 +159,7 @@ impl HttpTransactionHandler {
             );
         }
 
-        let params = match QueryParams::parse(req.uri().query()) {
+        let params = match QueryParams::parse(req.uri().query(), req.headers()) {
             Ok(p) => p,
             Err(msg) => {
                 metrics::http_tx_requests_inc("error", "unknown");
@@ -170,10 +210,10 @@ impl HttpTransactionHandler {
                     max_retries: params.max_retries,
                     ..Default::default()
                 },
-                forwarding_policies: vec![],
+                forwarding_policies: params.forwarding_policies.clone(),
             };
             self.tx_handler
-                .handle_raw_transaction(body_bytes.to_vec(), config)
+                .handle_raw_transaction(Bytes::clone(&body_bytes), config)
                 .await
         } else {
             let data = match String::from_utf8(body_bytes.to_vec()) {
@@ -199,7 +239,7 @@ impl HttpTransactionHandler {
                     max_retries: params.max_retries,
                     ..Default::default()
                 },
-                forwarding_policies: vec![],
+                forwarding_policies: params.forwarding_policies.clone(),
             };
             self.tx_handler.handle_transaction(data, Some(config)).await
         };
@@ -289,78 +329,93 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hyper::header::HeaderValue;
+
+    fn headers(values: &[(&'static str, &'static str)]) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        for (key, value) in values {
+            headers.insert(*key, HeaderValue::from_str(value).unwrap());
+        }
+        headers
+    }
 
     #[test]
     fn test_parse_defaults() {
-        let p = QueryParams::parse(None).unwrap();
+        let p = QueryParams::parse(None, &HeaderMap::new()).unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base58);
         assert_eq!(p.max_retries, None);
+        assert!(p.forwarding_policies.is_empty());
         assert_eq!(p.response, ResponseMode::None);
     }
 
     #[test]
     fn test_parse_encoding_base64() {
-        let p = QueryParams::parse(Some("encoding=base64")).unwrap();
+        let p = QueryParams::parse(Some("encoding=base64"), &HeaderMap::new()).unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base64);
     }
 
     #[test]
     fn test_parse_encoding_base58() {
-        let p = QueryParams::parse(Some("encoding=base58")).unwrap();
+        let p = QueryParams::parse(Some("encoding=base58"), &HeaderMap::new()).unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base58);
     }
 
     #[test]
     fn test_parse_encoding_invalid() {
-        assert!(QueryParams::parse(Some("encoding=json")).is_err());
+        assert!(QueryParams::parse(Some("encoding=json"), &HeaderMap::new()).is_err());
     }
 
     #[test]
     fn test_parse_multiple_params() {
-        let p = QueryParams::parse(Some("encoding=base58&max_retries=3")).unwrap();
+        let p =
+            QueryParams::parse(Some("encoding=base58&max_retries=3"), &HeaderMap::new()).unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base58);
         assert_eq!(p.max_retries, Some(3));
     }
 
     #[test]
     fn test_parse_unknown_params_ignored() {
-        let p = QueryParams::parse(Some("foo=bar&encoding=base58&baz=1")).unwrap();
+        let p =
+            QueryParams::parse(Some("foo=bar&encoding=base58&baz=1"), &HeaderMap::new()).unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base58);
     }
 
     #[test]
     fn test_parse_max_retries_invalid_ignored() {
-        let p = QueryParams::parse(Some("max_retries=abc")).unwrap();
+        let p = QueryParams::parse(Some("max_retries=abc"), &HeaderMap::new()).unwrap();
         assert_eq!(p.max_retries, None);
     }
 
     #[test]
     fn test_parse_response_signature() {
-        let p = QueryParams::parse(Some("response=signature")).unwrap();
+        let p = QueryParams::parse(Some("response=signature"), &HeaderMap::new()).unwrap();
         assert_eq!(p.response, ResponseMode::Signature);
     }
 
     #[test]
     fn test_parse_response_none() {
-        let p = QueryParams::parse(Some("response=none")).unwrap();
+        let p = QueryParams::parse(Some("response=none"), &HeaderMap::new()).unwrap();
         assert_eq!(p.response, ResponseMode::None);
     }
 
     #[test]
     fn test_parse_response_default_is_none() {
-        let p = QueryParams::parse(Some("encoding=base64")).unwrap();
+        let p = QueryParams::parse(Some("encoding=base64"), &HeaderMap::new()).unwrap();
         assert_eq!(p.response, ResponseMode::None);
     }
 
     #[test]
     fn test_parse_response_invalid() {
-        assert!(QueryParams::parse(Some("response=full")).is_err());
+        assert!(QueryParams::parse(Some("response=full"), &HeaderMap::new()).is_err());
     }
 
     #[test]
     fn test_parse_all_params() {
-        let p =
-            QueryParams::parse(Some("encoding=base58&max_retries=5&response=signature")).unwrap();
+        let p = QueryParams::parse(
+            Some("encoding=base58&max_retries=5&response=signature"),
+            &HeaderMap::new(),
+        )
+        .unwrap();
         assert_eq!(p.encoding, UiTransactionEncoding::Base58);
         assert_eq!(p.max_retries, Some(5));
         assert_eq!(p.response, ResponseMode::Signature);
@@ -368,13 +423,44 @@ mod tests {
 
     #[test]
     fn test_encoding_explicit_flag() {
-        let p = QueryParams::parse(Some("encoding=base64")).unwrap();
+        let p = QueryParams::parse(Some("encoding=base64"), &HeaderMap::new()).unwrap();
         assert!(p.encoding_explicit);
 
-        let p = QueryParams::parse(Some("max_retries=3")).unwrap();
+        let p = QueryParams::parse(Some("max_retries=3"), &HeaderMap::new()).unwrap();
         assert!(!p.encoding_explicit);
 
-        let p = QueryParams::parse(None).unwrap();
+        let p = QueryParams::parse(None, &HeaderMap::new()).unwrap();
         assert!(!p.encoding_explicit);
+    }
+
+    #[test]
+    fn test_parse_forwarding_policies_query() {
+        let p = QueryParams::parse(
+            Some("forwarding_policies=11111111111111111111111111111111,invalid"),
+            &HeaderMap::new(),
+        )
+        .unwrap();
+        assert_eq!(p.forwarding_policies.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_headers_override_query_values() {
+        let p = QueryParams::parse(
+            Some(
+                "max_retries=3&forwarding_policies=11111111111111111111111111111111&response=signature",
+            ),
+            &headers(&[
+                (X_JET_MAX_RETRIES, "5"),
+                (
+                    X_JET_FORWARDING_POLICIES,
+                    "Stake11111111111111111111111111111111111111,invalid",
+                ),
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(p.max_retries, Some(5));
+        assert_eq!(p.forwarding_policies.len(), 1);
+        assert_eq!(p.response, ResponseMode::Signature);
     }
 }

--- a/apps/jet/src/transaction_handler.rs
+++ b/apps/jet/src/transaction_handler.rs
@@ -4,6 +4,7 @@ use {
         transactions::SendTransactionRequest,
     },
     anyhow::Result,
+    bytes::Bytes,
     jsonrpsee::types::error::{ErrorObject, ErrorObjectOwned, INTERNAL_ERROR_CODE},
     solana_client::rpc_response::RpcVersionInfo,
     solana_rpc_client_api::config::RpcSendTransactionConfig,
@@ -107,7 +108,7 @@ impl TransactionHandler {
             .send(Arc::new(SendTransactionRequest {
                 signature,
                 transaction,
-                wire_transaction,
+                wire_transaction: wire_transaction.into(),
                 max_retries: config.max_retries,
                 policies: config_with_forwarding_policies.forwarding_policies,
             }))
@@ -118,7 +119,7 @@ impl TransactionHandler {
 
     pub async fn handle_raw_transaction(
         &self,
-        wire_transaction: Vec<u8>,
+        wire_transaction: Bytes,
         config_with_forwarding_policies: JetRpcSendTransactionConfig,
     ) -> Result<String /* Signature */, TransactionHandlerError> {
         if wire_transaction.len() > PACKET_DATA_SIZE {
@@ -129,8 +130,12 @@ impl TransactionHandler {
             )));
         }
 
-        let transaction: VersionedTransaction = bincode::deserialize(&wire_transaction)
-            .map_err(|e| TransactionHandlerError::InvalidParams(format!("failed to deserialize transaction: {e}")))?;
+        let transaction: VersionedTransaction = bincode::deserialize(wire_transaction.as_ref())
+            .map_err(|e| {
+                TransactionHandlerError::InvalidParams(format!(
+                    "failed to deserialize transaction: {e}"
+                ))
+            })?;
 
         transaction
             .sanitize()
@@ -166,7 +171,7 @@ impl TransactionHandler {
             .send(Arc::new(SendTransactionRequest {
                 signature,
                 transaction,
-                wire_transaction,
+                wire_transaction: wire_transaction.into(),
                 max_retries: config.max_retries,
                 policies: config_with_forwarding_policies.forwarding_policies,
             }))

--- a/apps/jet/src/transactions.rs
+++ b/apps/jet/src/transactions.rs
@@ -184,7 +184,7 @@ impl GrpcRootedTxReceiver {
 pub struct SendTransactionRequest {
     pub signature: Signature,
     pub transaction: VersionedTransaction,
-    pub wire_transaction: Vec<u8>,
+    pub wire_transaction: Bytes,
     pub max_retries: Option<usize>,
     pub policies: Vec<Pubkey>,
 }
@@ -772,7 +772,7 @@ impl TransactionFanout {
             let next_leaders = leader_schedule_service.leader_lookahead(fanout_count);
             let mut sent_mask = Vec::with_capacity(next_leaders.capacity());
             sent_mask.resize(next_leaders.len(), false);
-            let txn_wire = Bytes::from_owner(tx.wire_transaction);
+            let txn_wire = tx.wire_transaction.clone();
             for (i, dest) in next_leaders.iter().enumerate() {
                 if !policy_store_service.is_allowed(&tx.policies, dest)? {
                     // Report skip to Lewis


### PR DESCRIPTION
## Summary
- add `x-jet-max-retries` and `x-jet-forwarding-policies` header overrides for `/api/v1/transactions`
- support `forwarding_policies` in the query string and let headers win when both are present
- keep raw HTTP transaction bodies as `Bytes` end-to-end to avoid an extra allocation/copy

## Testing
- cargo check --manifest-path /workspaces/yellowstone-jet/apps/jet/Cargo.toml