### PR TITLE
Allow trusted simulated sendTransaction requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7157,7 +7157,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-jet"
-version = "14.9.7"
+version = "14.9.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/jet/Cargo.toml
+++ b/apps/jet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-jet"
-version = "14.9.7"
+version = "14.9.8"
 description = "Yellowstone Jet"
 edition.workspace = true
 authors.workspace = true

--- a/apps/jet/src/http_tx_handler.rs
+++ b/apps/jet/src/http_tx_handler.rs
@@ -21,7 +21,11 @@ use {
 };
 
 const API_TX_PATH: &str = "/api/v1/transactions";
+pub const SIMULATION_PERFORMED_HEADER: &str = "simulation-performed";
 const SOLANA_FORWARDING_POLICIES: &str = "solana-forwardingpolicies";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SimulationPerformed;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ResponseMode {
@@ -125,6 +129,13 @@ fn parse_forwarding_policies(value: &str) -> Vec<Pubkey> {
         .filter(|v| !v.is_empty())
         .filter_map(|v| Pubkey::from_str(v).ok())
         .collect()
+}
+
+fn simulation_performed(headers: &HeaderMap) -> bool {
+    headers
+        .get(SIMULATION_PERFORMED_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("true") || value == "1")
 }
 
 #[derive(Clone)]
@@ -313,6 +324,10 @@ where
             let handler = self.handler.clone();
             async move { Ok(handler.handle_request(request).await) }.boxed()
         } else {
+            let mut request = request;
+            if simulation_performed(request.headers()) {
+                request.extensions_mut().insert(SimulationPerformed);
+            }
             let fut = self.service.call(request);
             async move { fut.await.map_err(Into::into) }.boxed()
         }
@@ -429,5 +444,26 @@ mod tests {
         )
         .unwrap();
         assert_eq!(p.forwarding_policies.len(), 1);
+    }
+
+    #[test]
+    fn test_simulation_performed_header() {
+        assert!(!simulation_performed(&HeaderMap::new()));
+        assert!(!simulation_performed(&headers(&[(
+            SIMULATION_PERFORMED_HEADER,
+            "false",
+        )])));
+        assert!(simulation_performed(&headers(&[(
+            SIMULATION_PERFORMED_HEADER,
+            "true",
+        )])));
+        assert!(simulation_performed(&headers(&[(
+            SIMULATION_PERFORMED_HEADER,
+            "TRUE",
+        )])));
+        assert!(simulation_performed(&headers(&[(
+            SIMULATION_PERFORMED_HEADER,
+            "1",
+        )])));
     }
 }

--- a/apps/jet/src/rpc.rs
+++ b/apps/jet/src/rpc.rs
@@ -299,10 +299,12 @@ pub mod rpc_admin {
 pub mod rpc_solana_like {
     use {
         crate::{
-            metrics, payload::JetRpcSendTransactionConfig, rpc::invalid_params,
-            solana::decode_and_deserialize, transaction_handler::TransactionHandler,
+            http_tx_handler::SimulationPerformed, metrics, payload::JetRpcSendTransactionConfig,
+            rpc::invalid_params, solana::decode_and_deserialize,
+            transaction_handler::TransactionHandler,
         },
         jsonrpsee::{
+            Extensions,
             core::{RpcResult, async_trait},
             proc_macros::rpc,
         },
@@ -317,7 +319,7 @@ pub mod rpc_solana_like {
         #[method(name = "getVersion")]
         fn get_version(&self) -> RpcResult<RpcVersionInfo>;
 
-        #[method(name = "sendTransaction")]
+        #[method(name = "sendTransaction", with_extensions)]
         async fn send_transaction(
             &self,
             data: String,
@@ -360,6 +362,15 @@ pub mod rpc_solana_like {
         }
     }
 
+    fn apply_simulation_performed(
+        config_with_policies: &mut JetRpcSendTransactionConfig,
+        extensions: &Extensions,
+    ) {
+        if extensions.get::<SimulationPerformed>().is_some() {
+            config_with_policies.config.skip_preflight = true;
+        }
+    }
+
     #[async_trait]
     impl RpcServer for RpcServerImpl {
         fn get_version(&self) -> RpcResult<RpcVersionInfo> {
@@ -369,11 +380,13 @@ pub mod rpc_solana_like {
 
         async fn send_transaction(
             &self,
+            extensions: &Extensions,
             data: String,
             config_with_forwarding_policies: Option<JetRpcSendTransactionConfig>,
         ) -> RpcResult<String /* Signature */> {
             debug!("send_transaction rpc request received");
-            let config_with_policies = config_with_forwarding_policies.unwrap_or_default();
+            let mut config_with_policies = config_with_forwarding_policies.unwrap_or_default();
+            apply_simulation_performed(&mut config_with_policies, extensions);
             let config = config_with_policies.config;
 
             let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
@@ -387,6 +400,44 @@ pub mod rpc_solana_like {
 
             self.handle_internal_transaction(transaction, config_with_policies)
                 .await
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use {super::*, solana_rpc_client_api::config::RpcSendTransactionConfig};
+
+        #[test]
+        fn simulation_performed_extension_allows_preflight_requested_config() {
+            let mut extensions = Extensions::new();
+            extensions.insert(SimulationPerformed);
+            let mut config = JetRpcSendTransactionConfig {
+                config: RpcSendTransactionConfig {
+                    skip_preflight: false,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
+            apply_simulation_performed(&mut config, &extensions);
+
+            assert!(config.config.skip_preflight);
+        }
+
+        #[test]
+        fn missing_simulation_performed_extension_preserves_config() {
+            let extensions = Extensions::new();
+            let mut config = JetRpcSendTransactionConfig {
+                config: RpcSendTransactionConfig {
+                    skip_preflight: false,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
+            apply_simulation_performed(&mut config, &extensions);
+
+            assert!(!config.config.skip_preflight);
         }
     }
 }


### PR DESCRIPTION
## Summary
- detect the `simulation-performed` HTTP header on JSON-RPC requests and attach a typed request extension
- allow JSON-RPC `sendTransaction` configs with `skipPreflight=false` only when that trusted simulation marker is present
- keep `/api/v1/transactions` behavior unchanged and add focused unit tests

## Tests
- `cargo fmt --check`
- `cargo check -p yellowstone-jet`
- `cargo test -p yellowstone-jet --lib simulation_performed -j1`

Note: `cargo test -p yellowstone-jet simulation_performed` without `--lib -j1` hit a linker OOM (`ld` killed by signal 9) while building unrelated bins/integration tests.