### PR TITLE
fix(jet): fail health checks when transaction enqueue closes

### DIFF
--- a/apps/jet/src/http_tx_handler.rs
+++ b/apps/jet/src/http_tx_handler.rs
@@ -1,7 +1,8 @@
 use {
     crate::{
-        metrics::jet as metrics, payload::JetRpcSendTransactionConfig,
-        transaction_handler::TransactionHandler,
+        metrics::jet as metrics,
+        payload::JetRpcSendTransactionConfig,
+        transaction_handler::{TransactionHandler, TransactionHandlerError},
     },
     bytes::Bytes,
     futures::future::{BoxFuture, FutureExt},
@@ -269,7 +270,13 @@ impl HttpTransactionHandler {
                 if self.log_invalid_txn {
                     warn!(error = %e, "HTTP transaction submission failed");
                 }
-                text_response(StatusCode::BAD_REQUEST, &e.to_string())
+                let status = if matches!(e, TransactionHandlerError::TransactionPipelineUnavailable)
+                {
+                    StatusCode::SERVICE_UNAVAILABLE
+                } else {
+                    StatusCode::BAD_REQUEST
+                };
+                text_response(status, &e.to_string())
             }
         }
     }

--- a/apps/jet/src/metrics.rs
+++ b/apps/jet/src/metrics.rs
@@ -61,7 +61,10 @@ pub mod jet {
         },
         solana_clock::Slot,
         solana_pubkey::Pubkey,
-        std::{sync::Once, time::Duration},
+        std::{
+            sync::{Once, RwLock},
+            time::Duration,
+        },
     };
 
     lazy_static::lazy_static! {
@@ -86,6 +89,8 @@ pub mod jet {
         ).unwrap();
 
         static ref ROOTED_TRANSACTIONS_POOL_SIZE: IntGauge = IntGauge::new("rooted_transactions_pool_size", "Total number of transactions in landed pool").unwrap();
+        static ref TRANSACTION_PIPELINE_HEALTH: IntGauge = IntGauge::new("transaction_pipeline_health", "1 when the local transaction enqueue pipeline is healthy").unwrap();
+        static ref TRANSACTION_PIPELINE_LAST_ERROR: RwLock<Option<String>> = RwLock::new(None);
 
         static ref STS_POOL_SIZE: IntGauge = IntGauge::new("sts_pool_size", "Number of transactions in the pool").unwrap();
         static ref STS_INFLIGHT_SIZE: IntGauge = IntGauge::new("sts_inflight_size", "Number of transactions sending right now").unwrap();
@@ -275,6 +280,7 @@ pub mod jet {
             register!(GRPC_SLOT_RECEIVED);
 
             register!(ROOTED_TRANSACTIONS_POOL_SIZE);
+            register!(TRANSACTION_PIPELINE_HEALTH);
             register!(SEND_TRANSACTION_ATTEMPT);
             register!(SEND_TRANSACTION_ERROR);
             register!(SEND_TRANSACTION_SUCCESS);
@@ -312,6 +318,8 @@ pub mod jet {
 
             yellowstone_jet_tpu_client::prom::register_metrics(&REGISTRY);
             grpc_lewis::prom::register_metrics(&REGISTRY);
+
+            mark_transaction_pipeline_healthy();
         });
     }
 
@@ -360,8 +368,41 @@ pub mod jet {
             .set(1);
     }
 
+    pub fn mark_transaction_pipeline_healthy() {
+        TRANSACTION_PIPELINE_HEALTH.set(1);
+
+        if let Ok(mut last_error) = TRANSACTION_PIPELINE_LAST_ERROR.write() {
+            *last_error = None;
+        }
+    }
+
+    pub fn mark_transaction_pipeline_unhealthy(reason: impl Into<String>) {
+        TRANSACTION_PIPELINE_HEALTH.set(0);
+
+        if let Ok(mut last_error) = TRANSACTION_PIPELINE_LAST_ERROR.write() {
+            *last_error = Some(reason.into());
+        }
+    }
+
+    pub fn get_transaction_pipeline_health_status() -> anyhow::Result<()> {
+        if TRANSACTION_PIPELINE_HEALTH.get() > 0 {
+            return Ok(());
+        }
+
+        let reason = TRANSACTION_PIPELINE_LAST_ERROR
+            .read()
+            .ok()
+            .and_then(|last_error| last_error.clone())
+            .filter(|reason| !reason.is_empty())
+            .unwrap_or_else(|| "unknown error".to_owned());
+
+        anyhow::bail!("transaction pipeline unavailable: {reason}");
+    }
+
     // TODO:  this logic should not be in metrics module as its use for RPC admin module.
     pub fn get_health_status() -> anyhow::Result<()> {
+        get_transaction_pipeline_health_status()?;
+
         anyhow::ensure!(
             GRPC_SLOT_RECEIVED
                 .with_label_values(&[CommitmentLevel::Processed.as_str()])

--- a/apps/jet/src/transaction_handler.rs
+++ b/apps/jet/src/transaction_handler.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        payload::JetRpcSendTransactionConfig, solana::decode_and_deserialize,
-        transactions::SendTransactionRequest,
+        metrics::jet as jet_metrics, payload::JetRpcSendTransactionConfig,
+        solana::decode_and_deserialize, transactions::SendTransactionRequest,
     },
     anyhow::Result,
     bytes::Bytes,
@@ -33,6 +33,9 @@ pub enum TransactionHandlerError {
 
     #[error("unsupported encoding")]
     UnsupportedEncoding,
+
+    #[error("transaction pipeline unavailable")]
+    TransactionPipelineUnavailable,
 }
 
 impl TransactionHandlerError {
@@ -43,6 +46,9 @@ impl TransactionHandlerError {
             TransactionHandlerError::PreflightNotSupported => "PreflightNotSupported",
             TransactionHandlerError::InvalidParams(_) => "InvalidParams",
             TransactionHandlerError::UnsupportedEncoding => "UnsupportedEncoding",
+            TransactionHandlerError::TransactionPipelineUnavailable => {
+                "TransactionPipelineUnavailable"
+            }
         }
     }
 }
@@ -77,6 +83,19 @@ impl TransactionHandler {
         }
     }
 
+    fn enqueue_transaction(
+        &self,
+        request: SendTransactionRequest,
+    ) -> Result<(), TransactionHandlerError> {
+        self.transaction_sink.send(Arc::new(request)).map_err(|_| {
+            jet_metrics::mark_transaction_pipeline_unhealthy("transaction sink closed");
+            TransactionHandlerError::TransactionPipelineUnavailable
+        })?;
+
+        jet_metrics::mark_transaction_pipeline_healthy();
+        Ok(())
+    }
+
     pub async fn handle_versioned_transaction(
         &self,
         transaction: VersionedTransaction,
@@ -104,15 +123,13 @@ impl TransactionHandler {
             )));
         }
 
-        self.transaction_sink
-            .send(Arc::new(SendTransactionRequest {
-                signature,
-                transaction,
-                wire_transaction: wire_transaction.into(),
-                max_retries: config.max_retries,
-                policies: config_with_forwarding_policies.forwarding_policies,
-            }))
-            .expect("transaction sink closed");
+        self.enqueue_transaction(SendTransactionRequest {
+            signature,
+            transaction,
+            wire_transaction: wire_transaction.into(),
+            max_retries: config.max_retries,
+            policies: config_with_forwarding_policies.forwarding_policies,
+        })?;
 
         Ok(signature.to_string())
     }
@@ -143,15 +160,13 @@ impl TransactionHandler {
 
         let signature = transaction.signatures[0];
 
-        self.transaction_sink
-            .send(Arc::new(SendTransactionRequest {
-                signature,
-                transaction,
-                wire_transaction,
-                max_retries: config_with_forwarding_policies.config.max_retries,
-                policies: config_with_forwarding_policies.forwarding_policies,
-            }))
-            .expect("transaction sink closed");
+        self.enqueue_transaction(SendTransactionRequest {
+            signature,
+            transaction,
+            wire_transaction,
+            max_retries: config_with_forwarding_policies.config.max_retries,
+            policies: config_with_forwarding_policies.forwarding_policies,
+        })?;
 
         Ok(signature.to_string())
     }
@@ -167,15 +182,13 @@ impl TransactionHandler {
         let (wire_transaction, transaction) = self.prepare_transaction(data, config).await?;
         let signature = transaction.signatures[0];
 
-        self.transaction_sink
-            .send(Arc::new(SendTransactionRequest {
-                signature,
-                transaction,
-                wire_transaction: wire_transaction.into(),
-                max_retries: config.max_retries,
-                policies: config_with_forwarding_policies.forwarding_policies,
-            }))
-            .expect("transaction sink closed");
+        self.enqueue_transaction(SendTransactionRequest {
+            signature,
+            transaction,
+            wire_transaction: wire_transaction.into(),
+            max_retries: config.max_retries,
+            policies: config_with_forwarding_policies.forwarding_policies,
+        })?;
 
         Ok(signature.to_string())
     }
@@ -205,5 +218,70 @@ impl TransactionHandler {
             .map_err(|e| TransactionHandlerError::InvalidTransaction(e.to_string()))?;
 
         Ok((wire_transaction, transaction))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::metrics::jet as jet_metrics,
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_message::{VersionedMessage, v0},
+        solana_rpc_client_api::config::RpcSendTransactionConfig,
+        solana_signer::Signer,
+        solana_system_interface::instruction::transfer,
+    };
+
+    fn test_transaction() -> VersionedTransaction {
+        let payer = Keypair::new();
+        let receiver = Keypair::new();
+        let instructions = [transfer(&payer.pubkey(), &receiver.pubkey(), 1)];
+
+        VersionedTransaction::try_new(
+            VersionedMessage::V0(
+                v0::Message::try_compile(&payer.pubkey(), &instructions, &[], Hash::new_unique())
+                    .expect("try compile"),
+            ),
+            &[&payer],
+        )
+        .expect("try new")
+    }
+
+    fn send_config() -> JetRpcSendTransactionConfig {
+        JetRpcSendTransactionConfig {
+            config: RpcSendTransactionConfig {
+                skip_preflight: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn closed_transaction_sink_returns_pipeline_unavailable_and_marks_unhealthy() {
+        jet_metrics::mark_transaction_pipeline_healthy();
+        let (transaction_sink, transaction_source) = mpsc::unbounded_channel();
+        drop(transaction_source);
+
+        let handler = TransactionHandler::new(transaction_sink);
+        let err = handler
+            .handle_versioned_transaction(test_transaction(), send_config())
+            .await
+            .expect_err("closed sink should fail");
+
+        assert!(matches!(
+            err,
+            TransactionHandlerError::TransactionPipelineUnavailable
+        ));
+        assert!(
+            jet_metrics::get_transaction_pipeline_health_status()
+                .expect_err("closed sink should mark health unhealthy")
+                .to_string()
+                .contains("transaction sink closed")
+        );
+
+        jet_metrics::mark_transaction_pipeline_healthy();
     }
 }


### PR DESCRIPTION
## Summary
- replace `expect("transaction sink closed")` with a typed `TransactionPipelineUnavailable` error on all transaction enqueue paths
- add `transaction_pipeline_health` to Jet readiness so `/health` returns 503 when the local scheduler enqueue pipeline is closed
- return HTTP 503 for `/api/v1/transactions` when the enqueue pipeline is unavailable instead of treating it as a bad request
- add a regression test for a valid transaction submitted after the scheduler receiver is dropped

## Context
This addresses the Jet-side failure mode behind abrupt backend closes before HAProxy receives response headers. The enqueue failure means Jet cannot hand accepted transactions to its local scheduler; that should make the alloc fail readiness so Consul can stop routing to it until restart/recovery recreates the pipeline.

No Linear ticket — incident follow-up.

## Tests
- `cargo test --package yellowstone-jet`