### PR TITLE
Pollable tpu sender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ config-gentx-test.yml
 .local
 .env
 target
+.claude

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6395,6 +6395,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -7031,6 +7032,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "vergen",
  "yellowstone-grpc-client",
@@ -7041,7 +7043,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-jet-tpu-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7096,6 +7098,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "url",
  "x509-parser",
  "yellowstone-grpc-client",
  "yellowstone-grpc-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ tower = "0.5.0"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.1"
 uuid = "1.11.0"
+url = "2.0.0"
 vergen = "9.1.0"
 x509-parser = "0.18.1"
 
@@ -109,7 +110,7 @@ solana-transaction-error = "3.0.0"
 # Yellowstone
 yellowstone-grpc-client = "13.1.0"
 yellowstone-grpc-proto = "12.5.0"
-yellowstone-jet-tpu-client = { path = "crates/tpu-client", version = "0.4.0" }
+yellowstone-jet-tpu-client = { path = "crates/tpu-client", version = "0.5.0" }
 yellowstone-shield-store = "0.11.0"
 
 [workspace.lints.clippy]
@@ -117,6 +118,7 @@ clone_on_ref_ptr = "deny"
 missing_const_for_fn = "deny"
 trivially_copy_pass_by_ref = "deny"
 collapsible_if = "allow"
+result_large_err = "allow"
 
 [profile.release]
 codegen-units = 1

--- a/apps/jet/Cargo.toml
+++ b/apps/jet/Cargo.toml
@@ -57,7 +57,7 @@ tower = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "json"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
-
+url = { workspace = true, features = ["serde"] }
 # Agave Monorepo
 solana-bincode = { workspace = true }
 solana-client = { workspace = true }

--- a/apps/jet/src/bin/jet.rs
+++ b/apps/jet/src/bin/jet.rs
@@ -308,7 +308,7 @@ async fn run_jet(
     let blockhash_queue = BlockhashQueue::new(geyser.subscribe_block_meta());
 
     let rpc_client = Arc::new(solana_client::nonblocking::rpc_client::RpcClient::new(
-        config.upstream.rpc.clone(),
+        config.upstream.rpc.as_str().to_string(),
     ));
 
     let (cluster_tpu_info, cluster_tpu_info_tasks) = ClusterTpuInfo::new(

--- a/apps/jet/src/bin/lite-jet.rs
+++ b/apps/jet/src/bin/lite-jet.rs
@@ -44,7 +44,7 @@ use {
         core::{TpuSenderResponse, TpuSenderResponseCallback},
         yellowstone_grpc::sender::{
             Endpoints, NewYellowstoneTpuSender, ShieldBlockList, YellowstoneTpuSender,
-            create_yellowstone_tpu_sender_with_callback,
+            YellowstoneTpuSenderConfig, create_yellowstone_tpu_sender_with_callback,
         },
     },
     yellowstone_shield_store::PolicyStore,
@@ -222,13 +222,18 @@ async fn run_jet(
             }
         }
     }
+
+    let ys_tpu_sender_config = YellowstoneTpuSenderConfig {
+        endpoints: tpu_sender_endpoints.clone(),
+        ..Default::default()
+    };
+
     let NewYellowstoneTpuSender {
         sender,
         related_objects_jh,
     } = create_yellowstone_tpu_sender_with_callback(
-        Default::default(),
+        ys_tpu_sender_config,
         initial_identity.insecure_clone(),
-        tpu_sender_endpoints,
         LoggingCallback,
     )
     .await

--- a/apps/jet/src/config.rs
+++ b/apps/jet/src/config.rs
@@ -1,6 +1,7 @@
 use {
     crate::{feature_flags::FeatureSet, util::CommitmentLevel},
     anyhow::Context,
+    reqwest::Url,
     serde::{
         Deserialize,
         de::{self, Deserializer},
@@ -159,7 +160,7 @@ pub struct ConfigUpstream {
 
     /// RPC endpoint
     #[serde(default = "ConfigUpstream::default_rpc")]
-    pub rpc: String,
+    pub rpc: Url,
 
     ///
     /// RPC retry strategy
@@ -190,8 +191,8 @@ impl ConfigUpstream {
         }
     }
 
-    fn default_rpc() -> String {
-        "http://127.0.0.1:8899".to_owned()
+    fn default_rpc() -> Url {
+        Url::parse("http://127.0.0.1:8899").unwrap()
     }
 
     const fn default_cluster_nodes_update_interval() -> Duration {
@@ -207,15 +208,15 @@ impl ConfigUpstream {
 pub struct ConfigUpstreamGrpc {
     /// gRPC service endpoint
     #[serde(default = "ConfigUpstreamGrpc::default_endpoint")]
-    pub endpoint: String,
+    pub endpoint: Url,
 
     /// Optional token for access to gRPC
     pub x_token: Option<String>,
 }
 
 impl ConfigUpstreamGrpc {
-    fn default_endpoint() -> String {
-        "http://127.0.0.1:10000".to_owned()
+    fn default_endpoint() -> Url {
+        Url::parse("http://127.0.0.1:10000").unwrap()
     }
 }
 
@@ -228,9 +229,11 @@ impl From<ConfigUpstream> for PolicyStoreConfig {
         } = config;
 
         PolicyStoreConfig {
-            rpc: PolicyStoreRpcConfig { endpoint: rpc },
+            rpc: PolicyStoreRpcConfig {
+                endpoint: rpc.to_string(),
+            },
             grpc: PolicyStoreGrpcConfig {
-                endpoint,
+                endpoint: endpoint.to_string(),
                 x_token,
                 max_decoding_message_size: Some(100_000_000),
                 commitment: Some(ShieldStoreCommitmentLevel::Confirmed),

--- a/apps/jet/src/grpc_geyser.rs
+++ b/apps/jet/src/grpc_geyser.rs
@@ -234,7 +234,7 @@ impl GeyserSubscriber {
                     info!("gRPC subscriber: cancellation token triggered, shutting down...");
                     return Ok(());
                 },
-                result = Self::grpc_open(&endpoint, x_token.as_deref(), true, include_transactions) => {
+                result = Self::grpc_open(endpoint.as_str(), x_token.as_deref(), true, include_transactions) => {
                     result
                 }
                 _ = time::sleep(Duration::from_secs(30)) => {

--- a/apps/jet/src/lib.rs
+++ b/apps/jet/src/lib.rs
@@ -30,6 +30,7 @@ pub mod rpc;
 pub mod solana;
 pub mod solana_rpc_utils;
 pub mod stake;
+pub mod tpu_drain;
 pub mod transaction_handler;
 pub mod transactions;
 pub mod util;

--- a/apps/jet/src/tpu_drain.rs
+++ b/apps/jet/src/tpu_drain.rs
@@ -1,0 +1,112 @@
+use {
+    crate::transactions::SendTransactionRequest,
+    futures::{TryStream, TryStreamExt},
+    std::{
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll, ready},
+    },
+    yellowstone_jet_tpu_client::yellowstone_grpc::sender::{
+        PollYellowstoneTpuSender, SendErrorKind, ShieldBlockList, YellowstoneTpuSender,
+    },
+    yellowstone_shield_store::PolicyStore,
+};
+
+///
+/// A [`TpuDrain`] is a [`Future`] that continuously drains a stream of [`SendTransactionRequest`]s and sends them to a TPU sender ([`PollYellowstoneTpuSender`]) until the stream is exhausted or an error occurs.
+///
+pub struct TpuDrain<St> {
+    tpu_sender: PollYellowstoneTpuSender,
+    source: St,
+    shield_store: Option<PolicyStore>,
+}
+
+impl<St> TpuDrain<St> {
+    pub const fn new(
+        tpu_sender: YellowstoneTpuSender,
+        source: St,
+        shield_store: Option<PolicyStore>,
+    ) -> Self {
+        Self {
+            tpu_sender: PollYellowstoneTpuSender::new(tpu_sender),
+            source,
+            shield_store,
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum TpuSinkError {
+    #[error("slot tracker disconnected")]
+    SlotTrackerDisconnected,
+    #[error("managed leader schedule disconnected")]
+    ManagedLeaderScheduleDisconnected,
+}
+
+impl<St> Future for TpuDrain<St>
+where
+    St: TryStream<Ok = SendTransactionRequest> + Unpin,
+    St::Error: std::error::Error + Send + Sync + 'static,
+{
+    type Output = Result<(), TpuSinkError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        loop {
+            // `PollYellowstoneTpuSender` requires `poll_send` to return `Ready` before every
+            // `start_send_*` call -- this also drives any previously started send
+            // (across all of its destinations) to completion.
+            match ready!(this.tpu_sender.poll_send(cx)) {
+                Ok(()) => {}
+                Err(_e) => {
+                    // THIS ERROR HAPPENS WHEN THE UNDERLYING TPU SENDER CLOSES.
+                    // todo: maybe monitor the inner of the error once we have an alternative to lewis.
+                    return Poll::Ready(Ok(()));
+                }
+            }
+
+            let Some(result) = ready!(this.source.try_poll_next_unpin(cx)) else {
+                return Poll::Ready(Ok(()));
+            };
+
+            let Ok(request) = result else {
+                // A stream error occurred, we cannot continue processing transactions
+                return Poll::Ready(Ok(()));
+            };
+
+            let start_result = match &this.shield_store {
+                Some(shield_store) => {
+                    let blocklist = ShieldBlockList {
+                        policy_store: shield_store,
+                        shield_policy_addresses: &request.policies,
+                        default_return_value: true,
+                    };
+
+                    this.tpu_sender.start_send_txn_with_shield_policies(
+                        request.signature,
+                        request.wire_transaction,
+                        blocklist,
+                    )
+                }
+                None => this
+                    .tpu_sender
+                    .start_send_txn(request.signature, request.wire_transaction),
+            };
+
+            if let Err(e) = start_result {
+                tracing::error!("failed to send transaction: {e}");
+
+                match e.kind {
+                    SendErrorKind::Closed => return Poll::Ready(Ok(())),
+                    SendErrorKind::SlotTrackerDisconnected => {
+                        return Poll::Ready(Err(TpuSinkError::SlotTrackerDisconnected));
+                    }
+                    SendErrorKind::ManagedLeaderScheduleDisconnected => {
+                        return Poll::Ready(Err(TpuSinkError::ManagedLeaderScheduleDisconnected));
+                    }
+                    SendErrorKind::RemotePeerBlocked => continue,
+                }
+            }
+        }
+    }
+}

--- a/crates/tpu-client/Cargo.toml
+++ b/crates/tpu-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yellowstone-jet-tpu-client"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -16,18 +16,22 @@ exclude = ["src/bin/*"]
 [[bin]]
 name = "test-managed-schedule"
 path = "src/bin/test-managed-schedule.rs"
+required-features = ["examples"]
 
 [[bin]]
 name = "test-tpu-info"
 path = "src/bin/test-tpu-info.rs"
+required-features = ["examples"]
 
 [[bin]]
 name = "test-tpu-send"
 path = "src/bin/test-tpu-send.rs"
+required-features = ["examples"]
 
 [[bin]]
 name = "test-slot-tracker"
 path = "src/bin/test-slot-tracker.rs"
+required-features = ["examples"]
 
 [features]
 default = ["yellowstone-grpc"]
@@ -84,6 +88,7 @@ tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "json"], optional = true }
+url = { workspace = true, features = ["serde"] }
 
 # Agave Monorepo
 solana-client = { workspace = true }
@@ -116,6 +121,7 @@ yellowstone-shield-store = { workspace = true, optional = true }
 
 [dev-dependencies]
 x509-parser = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "json"] }
 
 [lints]
 workspace = true

--- a/crates/tpu-client/src/bin/test-managed-schedule.rs
+++ b/crates/tpu-client/src/bin/test-managed-schedule.rs
@@ -130,12 +130,12 @@ async fn main() {
         tokio::select! {
             _ = interval.tick() => {},
             _ = &mut ctrlc => break,
-            _ = &mut slot_tracker_jh => {
-                tracing::error!("Yellowstone slot tracker task exited unexpectedly");
-                break;
-            }
             _ = &mut managed_leader_schedule_jh => {
                 tracing::error!("managed leader schedule task exited unexpectedly");
+                break;
+            }
+            _ = &mut slot_tracker_jh => {
+                tracing::error!("Yellowstone slot tracker task exited unexpectedly");
                 break;
             }
         }

--- a/crates/tpu-client/src/bin/test-tpu-send.rs
+++ b/crates/tpu-client/src/bin/test-tpu-send.rs
@@ -18,10 +18,11 @@ use {
     },
     tracing::level_filters::LevelFilter,
     tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt},
+    url::Url,
     yellowstone_jet_tpu_client::{
         core::TpuSenderResponse,
         yellowstone_grpc::sender::{
-            Endpoints, NewYellowstoneTpuSender, YellowstoneTpuSender,
+            Endpoints, NewYellowstoneTpuSender, YellowstoneTpuSender, YellowstoneTpuSenderConfig,
             create_yellowstone_tpu_sender_with_callback,
         },
     },
@@ -92,14 +93,20 @@ async fn main() {
 
     let rpc_endpoint = match args.rpc {
         Some(endpoint) => endpoint,
-        None => env::var("RPC_ENDPOINT")
-            .expect("RPC_ENDPOINT must be set in dotenv file or environment"),
+        None => Url::parse(
+            &env::var("RPC_ENDPOINT")
+                .expect("RPC_ENDPOINT must be set in dotenv file or environment"),
+        )
+        .expect("Failed to parse RPC_ENDPOINT"),
     };
 
     let grpc_endpoint = match args.grpc {
         Some(endpoint) => endpoint,
-        None => env::var("GRPC_ENDPOINT")
-            .expect("GRPC_ENDPOINT must be set in dotenv file or environment"),
+        None => Url::parse(
+            &env::var("GRPC_ENDPOINT")
+                .expect("GRPC_ENDPOINT must be set in dotenv file or environment"),
+        )
+        .expect("Failed to parse GRPC_ENDPOINT"),
     };
 
     let grpc_x_token = match args.x_token {
@@ -131,7 +138,7 @@ async fn main() {
     };
 
     let rpc_client = Arc::new(RpcClient::new_with_commitment(
-        rpc_endpoint.clone(),
+        rpc_endpoint.to_string(),
         CommitmentConfig::confirmed(),
     ));
 
@@ -141,19 +148,18 @@ async fn main() {
         grpc: grpc_endpoint,
         grpc_x_token,
     };
+    let config = YellowstoneTpuSenderConfig {
+        endpoints,
+        ..Default::default()
+    };
 
     let (callback_tx, mut callback_rx) = tokio::sync::mpsc::unbounded_channel();
     let NewYellowstoneTpuSender {
         sender,
         related_objects_jh: _,
-    } = create_yellowstone_tpu_sender_with_callback(
-        Default::default(),
-        identity.insecure_clone(),
-        endpoints,
-        callback_tx,
-    )
-    .await
-    .expect("tpu-sender");
+    } = create_yellowstone_tpu_sender_with_callback(config, identity.insecure_clone(), callback_tx)
+        .await
+        .expect("tpu-sender");
 
     const LAMPORTS: u64 = 1000;
 
@@ -198,9 +204,9 @@ struct Args {
     dotenv: Option<PathBuf>,
     /// Endpoint to Yellowstone gRPC service
     #[clap(long, short)]
-    rpc: Option<String>,
+    rpc: Option<Url>,
     #[clap(long, short)]
-    grpc: Option<String>,
+    grpc: Option<Url>,
     /// X-Token for Yellowstone gRPC service
     x_token: Option<String>,
     ///

--- a/crates/tpu-client/src/core.rs
+++ b/crates/tpu-client/src/core.rs
@@ -43,6 +43,7 @@ use crate::prom;
 use {
     crate::config::{TpuOverrideInfo, TpuPortKind, TpuSenderConfig},
     bytes::Bytes,
+    core::fmt,
     derive_more::Display,
     futures::task::AtomicWaker,
     quinn::{
@@ -58,11 +59,12 @@ use {
     solana_tls_utils::{QuicClientCertificate, SkipServerVerification, new_dummy_x509_certificate},
     std::{
         collections::{BTreeMap, HashMap, HashSet, VecDeque},
+        future,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         num::NonZeroUsize,
         pin::Pin,
-        sync::{Arc, Mutex as StdMutex, atomic::AtomicBool},
-        task::Poll,
+        sync::{Arc, Mutex as StdMutex, atomic::AtomicU8},
+        task::{Poll, ready},
         time::{Duration, Instant},
     },
     tokio::{
@@ -74,6 +76,7 @@ use {
         task::{self, Id, JoinError, JoinHandle, JoinSet},
         time::{Sleep, interval},
     },
+    tokio_util::sync::PollSender,
 };
 
 /// This has been copy-pasted from `solana_streamer::nonblocking::quic::ALPN_TPU_PROTOCOL_ID`
@@ -132,12 +135,40 @@ struct ConnectingMeta {
     created_at: Instant,
 }
 
+struct UpdateIdentityCallback {
+    shared: Option<Arc<UpdateIdentityInner>>,
+}
+
+impl Drop for UpdateIdentityCallback {
+    fn drop(&mut self) {
+        if let Some(shared) = self.shared.take() {
+            shared.state.store(
+                UpdateIdentityInner::CANCELED,
+                std::sync::atomic::Ordering::Release,
+            );
+            shared.waker.wake();
+        }
+    }
+}
+
+impl UpdateIdentityCallback {
+    fn callback(mut self) {
+        if let Some(shared) = self.shared.take() {
+            shared.state.store(
+                UpdateIdentityInner::TRUE,
+                std::sync::atomic::Ordering::Release,
+            );
+            shared.waker.wake();
+        }
+    }
+}
+
 ///
 /// Inner part of the update identity command.
 ///
 struct UpdateIdentityCommand {
     new_identity: Keypair,
-    callback: Arc<UpdateIdentityInner>,
+    callback: UpdateIdentityCallback,
 }
 
 struct MultiStepIdentitySynchronizationCommand {
@@ -149,8 +180,23 @@ struct MultiStepIdentitySynchronizationCommand {
 /// Command to control driver behavior.
 ///
 enum DriverCommand {
-    UpdateIdenttiy(UpdateIdentityCommand),
+    UpdateIdentity(UpdateIdentityCommand),
     MultiStepIdentitySynchronization(MultiStepIdentitySynchronizationCommand),
+}
+
+impl fmt::Debug for DriverCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DriverCommand::UpdateIdentity(cmd) => f
+                .debug_struct("UpdateIdentity")
+                .field("new_identity", &cmd.new_identity.pubkey())
+                .finish(),
+            DriverCommand::MultiStepIdentitySynchronization(cmd) => f
+                .debug_struct("MultiStepIdentitySynchronization")
+                .field("new_identity", &cmd.new_identity.pubkey())
+                .finish(),
+        }
+    }
 }
 
 enum DriverTaskMeta {
@@ -1641,7 +1687,7 @@ where
                     prom::incr_quic_gw_tx_connection_cache_miss_cnt();
                 }
             }
-            tracing::warn!(
+            tracing::debug!(
                 "Skipping connection attempt to remote peer: {} since it is already connecting",
                 remote_peer_identity
             );
@@ -1649,7 +1695,7 @@ where
         }
 
         if self.being_evicted_peers.contains(&remote_peer_identity) {
-            tracing::warn!(
+            tracing::debug!(
                 "Skipping connection attempt to remote peer: {} since it is being evicted",
                 remote_peer_identity
             );
@@ -1660,7 +1706,7 @@ where
             .tx_worker_handle_map
             .contains_key(&remote_peer_identity)
         {
-            tracing::warn!(
+            tracing::debug!(
                 "Skipping connection attempt to remote peer: {} since it already has a worker",
                 remote_peer_identity
             );
@@ -2137,7 +2183,7 @@ where
                                 // EACH REATTEMPT SPAWNS A NEW CONNECTING TASK WITH ATTEMPT COUNT EQUALS TO PREVIOUS ATTEMPT COUNT + 1.
                                 // AFTER REACHING MAX ATTEMPTS, THE DEFAULT MATCH BRANCH WILL HANDLE THE FAILURE CALLED "whatever".
 
-                                tracing::warn!(
+                                tracing::info!(
                                     "Connection attempt {} to remote peer: {multiplexed_remote_peer_identity_vec:?} failed, retrying...",
                                     connection_attempt
                                 );
@@ -2696,16 +2742,13 @@ where
 
     async fn handle_cnc(&mut self, command: DriverCommand) {
         match command {
-            DriverCommand::UpdateIdenttiy(cmd) => {
+            DriverCommand::UpdateIdentity(cmd) => {
                 let UpdateIdentityCommand {
                     new_identity,
                     callback,
                 } = cmd;
                 let fake_barrier = async {
-                    callback
-                        .set
-                        .store(true, std::sync::atomic::Ordering::SeqCst);
-                    callback.waker.wake();
+                    callback.callback();
                 };
                 self.update_identity(new_identity, fake_barrier).await;
             }
@@ -3382,7 +3425,7 @@ impl TpuSenderDriverSpawner {
         TpuSenderSessionContext {
             driver_tx_sink: tx_inlet,
             identity_updater: TpuSenderIdentityUpdater {
-                cnc_tx: driver_cnc_tx,
+                cnc_tx: PollSender::new(driver_cnc_tx),
             },
             driver_join_handle: jh,
         }
@@ -3392,11 +3435,12 @@ impl TpuSenderDriverSpawner {
 ///
 /// Handle to update the identity used by the TPU sender driver.
 ///
+#[derive(Clone)]
 pub struct TpuSenderIdentityUpdater {
     ///
     /// Command-and-control channel to send command to the QUIC driver
     ///  
-    cnc_tx: mpsc::Sender<DriverCommand>,
+    cnc_tx: PollSender<DriverCommand>,
 }
 
 ///
@@ -3406,25 +3450,25 @@ impl TpuSenderIdentityUpdater {
     ///
     /// Changes the configured identity in the QUIC driver
     ///
-    pub async fn update_identity(&mut self, identity: Keypair) {
+    pub fn update_identity(&mut self, identity: Keypair) -> UpdateIdentity {
         let shared = UpdateIdentityInner {
-            set: AtomicBool::new(false),
+            state: AtomicU8::new(UpdateIdentityInner::FALSE),
             waker: AtomicWaker::new(),
         };
         let shared = Arc::new(shared);
+        let callback = UpdateIdentityCallback {
+            shared: Some(Arc::clone(&shared)),
+        };
         let cmd = UpdateIdentityCommand {
             new_identity: identity,
-            callback: Arc::clone(&shared),
+            callback,
         };
-        self.cnc_tx
-            .send(DriverCommand::UpdateIdenttiy(cmd))
-            .await
-            .expect("disconnected");
-        let update_identity = UpdateIdentity {
+        let cnc_tx = self.cnc_tx.clone();
+
+        UpdateIdentity {
             inner: shared,
-            _this: self,
-        };
-        update_identity.await
+            state: UpdateIdentityState::Init { cnc_tx, cmd },
+        }
     }
 
     ///
@@ -3446,10 +3490,26 @@ impl TpuSenderIdentityUpdater {
             new_identity: identity,
             barrier,
         };
-        self.cnc_tx
-            .send(DriverCommand::MultiStepIdentitySynchronization(cmd))
+        let mut cnc_tx = self.cnc_tx.clone();
+        future::poll_fn(|cx| cnc_tx.poll_reserve(cx))
             .await
             .expect("disconnected");
+        cnc_tx
+            .send_item(DriverCommand::MultiStepIdentitySynchronization(cmd))
+            .expect("disconnected");
+    }
+
+    ///
+    /// Builds a [`TpuSenderIdentityUpdater`] backed by an already-closed channel, for use in
+    /// tests that only need a placeholder value (e.g. to construct a [`TpuSender`](crate::sender::TpuSender))
+    /// and don't exercise identity updates.
+    ///
+    #[cfg(test)]
+    pub(crate) fn new_test_disconnected() -> Self {
+        let (cnc_tx, _cnc_rx) = tokio::sync::mpsc::channel(1);
+        Self {
+            cnc_tx: PollSender::new(cnc_tx),
+        }
     }
 }
 
@@ -3457,37 +3517,105 @@ impl TpuSenderIdentityUpdater {
 /// The shared state used to notify the completion of the identity update.
 /// See [`UpdateIdentity`] for more details.
 struct UpdateIdentityInner {
-    set: AtomicBool,
+    state: AtomicU8,
     waker: AtomicWaker,
+}
+
+// impl Drop for UpdateIdentityInner {
+//     fn drop(&mut self) {
+//         // If the future is dropped before the identity update is completed, we need to notify the driver to cancel the update.
+//         let last_state = self.state.load(std::sync::atomic::Ordering::Acquire);
+//         if last_state == UpdateIdentityInner::TRUE || last_state == UpdateIdentityInner::CANCELED_FLAG {
+//             // The update has already completed or been canceled, no need to do anything.
+//             return;
+//         }
+//         self.state
+//             .store(UpdateIdentityInner::CANCELED_FLAG, std::sync::atomic::Ordering::SeqCst);
+//         self.waker.wake();
+//     }
+// }
+
+impl UpdateIdentityInner {
+    const FALSE: u8 = 0;
+    const TRUE: u8 = 1;
+    // the last bit is used to indicate that the update has been canceled, and the future should return an error.
+    const CANCELED: u8 = 0x80;
+}
+
+#[allow(clippy::large_enum_variant)]
+enum UpdateIdentityState {
+    Init {
+        cnc_tx: PollSender<DriverCommand>,
+        cmd: UpdateIdentityCommand,
+    },
+    Closed,
+    WaitingForCompletion,
 }
 
 ///
 /// Future that waits for the identity update to complete.
 /// This future is used to ensure that the identity update is completed before proceeding.
 ///
-pub struct UpdateIdentity<'a> {
+pub struct UpdateIdentity {
     inner: Arc<UpdateIdentityInner>,
-    _this: &'a TpuSenderIdentityUpdater, /* phantom data to prevent two threads from updating the identity at the same time */
+    state: UpdateIdentityState,
 }
 
-impl Future for UpdateIdentity<'_> {
-    type Output = ();
+impl UpdateIdentity {
+    const fn take_state(&mut self) -> UpdateIdentityState {
+        std::mem::replace(&mut self.state, UpdateIdentityState::Closed)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("tpu sender runtime closed")]
+pub struct UpdateIdentityError;
+
+impl Future for UpdateIdentity {
+    type Output = Result<(), UpdateIdentityError>;
 
     fn poll(
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        // quick check to avoid registration if already done.
-        if self.inner.set.load(std::sync::atomic::Ordering::Relaxed) {
-            return Poll::Ready(());
-        }
+        let this = self.get_mut();
 
-        self.inner.waker.register(cx.waker());
+        let (result, next_state) = match this.take_state() {
+            UpdateIdentityState::Init { mut cnc_tx, cmd } => {
+                match ready!(cnc_tx.poll_reserve(cx)) {
+                    Ok(()) => {
+                        match cnc_tx.send_item(DriverCommand::UpdateIdentity(cmd)) {
+                            Ok(()) => {
+                                this.inner.waker.register(cx.waker());
+                                // Between the time we send and the registration, the driver may have already completed the update and set the atomic bool.
+                                // So we need to immediately wake the waker, so that the next poll will check the atomic bool and return ready if the update is already complete.
+                                cx.waker().wake_by_ref();
+                                (None, UpdateIdentityState::WaitingForCompletion)
+                            }
+                            Err(_) => (Some(Err(UpdateIdentityError)), UpdateIdentityState::Closed),
+                        }
+                    }
+                    Err(_) => (Some(Err(UpdateIdentityError)), UpdateIdentityState::Closed),
+                }
+            }
+            UpdateIdentityState::WaitingForCompletion => {
+                match this.inner.state.load(std::sync::atomic::Ordering::Relaxed) {
+                    UpdateIdentityInner::TRUE => (Some(Ok(())), UpdateIdentityState::Closed),
+                    UpdateIdentityInner::FALSE => (None, UpdateIdentityState::WaitingForCompletion),
+                    UpdateIdentityInner::CANCELED => {
+                        (Some(Err(UpdateIdentityError)), UpdateIdentityState::Closed)
+                    }
+                    _ => panic!("Unexpected state"),
+                }
+            }
+            UpdateIdentityState::Closed => {
+                panic!("UpdateIdentity polled after completion");
+            }
+        };
 
-        // Need to check condition **after** `register` to avoid a race
-        // condition that would result in lost notifications.
-        if self.inner.set.load(std::sync::atomic::Ordering::Relaxed) {
-            Poll::Ready(())
+        this.state = next_state;
+        if let Some(result) = result {
+            Poll::Ready(result)
         } else {
             Poll::Pending
         }
@@ -3508,15 +3636,35 @@ mod test {
         solana_pubkey::Pubkey,
         std::time::Duration,
         tokio::sync::mpsc,
+        tokio_util::sync::PollSender,
     };
+
+    #[tokio::test]
+    async fn update_identity_should_return_error_if_dropped_before_completion() {
+        let (cnc_tx, cnc_rx) = mpsc::channel(10);
+        let mut updater: TpuSenderIdentityUpdater = TpuSenderIdentityUpdater {
+            cnc_tx: PollSender::new(cnc_tx),
+        };
+
+        let identity = Keypair::new();
+        let mut update_fut = updater.update_identity(identity.insecure_clone());
+        let xs = futures::poll!(&mut update_fut);
+        assert!(xs.is_pending());
+        drop(updater);
+        drop(cnc_rx);
+        let result = update_fut.await;
+        assert!(result.is_err());
+    }
 
     #[tokio::test]
     async fn test_update_identity_fut() {
         let (cnc_tx, mut cnc_rx) = mpsc::channel(10);
-        let mut updater = TpuSenderIdentityUpdater { cnc_tx };
+        let mut updater = TpuSenderIdentityUpdater {
+            cnc_tx: PollSender::new(cnc_tx),
+        };
 
         let jh = tokio::spawn(async move {
-            let DriverCommand::UpdateIdenttiy(UpdateIdentityCommand {
+            let DriverCommand::UpdateIdentity(UpdateIdentityCommand {
                 new_identity,
                 callback,
             }) = cnc_rx.recv().await.unwrap()
@@ -3525,15 +3673,15 @@ mod test {
             };
             tokio::time::sleep(Duration::from_secs(2)).await;
             // This can be relaxed because `wake` hides `Released` memory barrier.
-            callback
-                .set
-                .store(true, std::sync::atomic::Ordering::Relaxed);
-            callback.waker.wake();
+            callback.callback();
             new_identity
         });
 
         let identity = Keypair::new();
-        updater.update_identity(identity.insecure_clone()).await;
+        updater
+            .update_identity(identity.insecure_clone())
+            .await
+            .unwrap();
 
         let actual = jh.await.unwrap();
         assert_eq!(actual, identity)

--- a/crates/tpu-client/src/rpc/schedule.rs
+++ b/crates/tpu-client/src/rpc/schedule.rs
@@ -9,6 +9,7 @@ use {
         sync::{Arc, RwLock, atomic::AtomicBool},
     },
     tokio::task::JoinHandle,
+    tokio_util::sync::CancellationToken,
 };
 
 pub const DEFAULT_AUTO_LEADER_SCHEDULE_CHECK_INTERVAL: std::time::Duration =
@@ -146,14 +147,24 @@ struct InnerManagedLeaderSchedule {
 #[derive(Clone)]
 pub struct ManagedLeaderSchedule {
     inner: Arc<RwLock<InnerManagedLeaderSchedule>>,
+    shutdown: CancellationToken,
+}
+
+impl Drop for ManagedLeaderSchedule {
+    fn drop(&mut self) {
+        // Stop the background update loop when the last schedule handle is dropped.
+        if Arc::strong_count(&self.inner) == 1 {
+            self.shutdown.cancel();
+        }
+    }
 }
 
 ///
 /// Error indicating that the AutoLeaderSchedule background update task has failed.
 ///
 #[derive(Debug, thiserror::Error)]
-#[error("auto leader schedule poisoned")]
-pub struct PoisonError;
+#[error("auto leader schedule disconnected")]
+pub struct GetLeaderError;
 
 impl ManagedLeaderSchedule {
     ///
@@ -163,18 +174,18 @@ impl ManagedLeaderSchedule {
     ///
     /// - `Ok(Some(Pubkey))` if the leader for the slot is found.
     /// - `Ok(None)` if the slot is out of range of the current schedules.
-    /// - `Err(PoisonError)` if the background update task has failed.
+    /// - `Err(GetLeaderError)` if the background update task has failed.
     ///
     /// # Errors
     ///
-    /// Returns `PoisonError` if the background update task has failed.
+    /// Returns `GetLeaderError` if the background update task has failed.
     ///
-    pub fn get_leader(&self, slot: u64) -> Result<Option<Pubkey>, PoisonError> {
+    pub fn get_leader(&self, slot: u64) -> Result<Option<Pubkey>, GetLeaderError> {
         let schedules = self.inner.read().unwrap();
         // Relaxed ordering is sufficient here since fail does not protect any data.
         // We already use RwLock to protect the double_buffer data.
         if schedules.fail.load(std::sync::atomic::Ordering::Relaxed) {
-            return Err(PoisonError);
+            return Err(GetLeaderError);
         }
         let schedule = if slot >= schedules.double_buffer[1].first_slot {
             &schedules.double_buffer[1]
@@ -183,13 +194,37 @@ impl ManagedLeaderSchedule {
         };
         Ok(schedule.get(&slot).cloned())
     }
+
+    ///
+    /// Builds a [`ManagedLeaderSchedule`] with a fixed, never-updating schedule, for tests that
+    /// need deterministic leader lookups without spawning [`spawn_managed_leader_schedule`]'s
+    /// background RPC polling.
+    ///
+    /// `first_slot` is the first slot of the epoch `schedule` covers; `schedule` holds one
+    /// pubkey per 4-slot leader boundary, starting at `first_slot` (see [`CompactSortedSchedule::get`]).
+    /// The same schedule is used for both the current and next epoch's double buffer.
+    ///
+    #[cfg(any(test, feature = "intg-testing"))]
+    pub fn new_for_test(first_slot: u64, schedule: Vec<Pubkey>) -> Self {
+        let compact = CompactSortedSchedule {
+            first_slot,
+            schedule,
+        };
+        Self {
+            inner: Arc::new(RwLock::new(InnerManagedLeaderSchedule {
+                double_buffer: [compact.clone(), compact],
+                fail: AtomicBool::new(false),
+            })),
+            shutdown: CancellationToken::new(),
+        }
+    }
 }
 
 async fn auto_leader_schedule_loop(
     config: ManagedLeaderScheduleConfig,
     shared: Arc<RwLock<InnerManagedLeaderSchedule>>,
     rpc_client: Arc<RpcClient>,
-    cancellation_token: tokio_util::sync::CancellationToken,
+    cancellation_token: CancellationToken,
 ) {
     pub struct OnDrop {
         shared: Option<Arc<RwLock<InnerManagedLeaderSchedule>>>,
@@ -345,13 +380,19 @@ pub async fn spawn_managed_leader_schedule(
     }));
 
     let shared_clone = Arc::clone(&shared);
-    let cancellation_token = tokio_util::sync::CancellationToken::new();
+    let cancellation_token = CancellationToken::new();
     let loop_ct = cancellation_token.clone();
     let jh = tokio::spawn(async move {
         auto_leader_schedule_loop(config, shared_clone, rpc_client, loop_ct).await;
     });
 
-    Ok((ManagedLeaderSchedule { inner: shared }, jh))
+    Ok((
+        ManagedLeaderSchedule {
+            inner: shared,
+            shutdown: cancellation_token,
+        },
+        jh,
+    ))
 }
 
 #[cfg(test)]
@@ -362,6 +403,34 @@ mod tests {
         solana_pubkey::Pubkey,
         std::collections::BTreeMap,
     };
+
+    #[test]
+    fn drop_of_non_last_clone_does_not_cancel_shutdown() {
+        let schedule = super::ManagedLeaderSchedule::new_for_test(0, vec![Pubkey::new_unique()]);
+        let shutdown = schedule.shutdown.clone();
+        let schedule2 = schedule.clone();
+
+        drop(schedule);
+        assert!(
+            !shutdown.is_cancelled(),
+            "dropping one clone must not cancel while another clone exists"
+        );
+
+        drop(schedule2);
+        assert!(
+            shutdown.is_cancelled(),
+            "dropping the last clone must cancel shutdown"
+        );
+    }
+
+    #[test]
+    fn drop_of_last_instance_cancels_shutdown() {
+        let schedule = super::ManagedLeaderSchedule::new_for_test(0, vec![Pubkey::new_unique()]);
+        let shutdown = schedule.shutdown.clone();
+
+        drop(schedule);
+        assert!(shutdown.is_cancelled(), "last drop must cancel shutdown");
+    }
 
     fn exponential_distribution(n: usize, base: f64, r: f64) -> Vec<u64> {
         // returns a vector of stake weights

--- a/crates/tpu-client/src/sender.rs
+++ b/crates/tpu-client/src/sender.rs
@@ -4,12 +4,18 @@ use {
         core::{
             ConnectionEvictionStrategy, LeaderTpuInfoService, TpuSenderDriverSpawner,
             TpuSenderIdentityUpdater, TpuSenderResponseCallback, TpuSenderSessionContext,
-            TpuSenderTxn, UpcomingLeaderPredictor, ValidatorStakeInfoService,
+            TpuSenderTxn, UpcomingLeaderPredictor, UpdateIdentity, ValidatorStakeInfoService,
         },
     },
+    futures::{Sink, SinkExt},
     solana_keypair::Keypair,
-    std::sync::Arc,
-    tokio::sync::{Mutex, mpsc},
+    std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        pin::Pin,
+        sync::Arc,
+        task::{Context, Poll, ready},
+    },
+    tokio_util::sync::PollSender,
 };
 
 ///
@@ -23,33 +29,74 @@ pub struct TpuSender {
     // The identity updater shared with the TPU sender task.
     // The [`TpuSenderIdentityUpdater`] cannot be cloned or called concurrently, so we wrap it in a Mutex.
     // We do this pre-cautionarily to avoid potential issues with miss-managed identity updates.
-    identity_updated: Arc<Mutex<TpuSenderIdentityUpdater>>,
-    txn_tx: mpsc::Sender<TpuSenderTxn>,
+    identity_updater: TpuSenderIdentityUpdater,
+    txn_tx: PollSender<TpuSenderTxn>,
+}
+
+impl From<TpuSender> for PollTpuSender {
+    fn from(sender: TpuSender) -> Self {
+        Self::new(sender)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
 #[error("disconnected")]
-pub struct TpuSenderError(TpuSenderTxn);
+pub struct TpuSenderError(Option<TpuSenderTxn>);
+
+impl TpuSenderError {
+    pub fn into_inner(self) -> Option<TpuSenderTxn> {
+        self.0
+    }
+}
 
 impl TpuSender {
     ///
     /// Sends a transaction to the TPU sender task.
     ///
+    /// # Arguments
+    ///
+    /// - `txn`: The [`TpuSenderTxn`] to send
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` once the transaction has been handed off to the TPU sender task, or
+    /// `Err(TpuSenderError)` if the TPU sender task is disconnected. On error, the transaction is
+    /// recoverable via `TpuSenderError::into_inner()`.
+    ///
+    /// # Notes
+    ///
+    /// This function does not send anything until the returned future is polled (e.g. via
+    /// `.await`).
+    ///
     pub async fn send_txn(&mut self, txn: TpuSenderTxn) -> Result<(), TpuSenderError> {
-        // I put &mut self here to indicate that the caller should not be sending txns concurrently from multiple tasks.
-        // This is the be consistent with the rest of the API which uses &mut self for updating identity.
-        self.txn_tx.send(txn).await.map_err(|e| TpuSenderError(e.0))
+        self.txn_tx
+            .send(txn)
+            .await
+            .map_err(|e| TpuSenderError(e.into_inner()))
     }
 
     ///
     /// Updates the identity used by the TPU sender.
     ///
-    pub async fn update_identity(&mut self, new_identity: Keypair) {
-        self.identity_updated
-            .lock()
-            .await
-            .update_identity(new_identity)
-            .await;
+    pub fn update_identity(&mut self, new_identity: Keypair) -> UpdateIdentity {
+        self.identity_updater.update_identity(new_identity)
+    }
+
+    ///
+    /// Builds a [`TpuSender`] backed by a plain in-memory channel of the given capacity, for
+    /// tests that need a working [`TpuSender`]/[`PollTpuSender`] without spawning the real TPU
+    /// sender driver. Returns the paired receiver so tests can observe what gets sent.
+    ///
+    #[cfg(test)]
+    pub(crate) fn new_test(
+        channel_capacity: usize,
+    ) -> (Self, tokio::sync::mpsc::Receiver<TpuSenderTxn>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(channel_capacity);
+        let sender = Self {
+            identity_updater: TpuSenderIdentityUpdater::new_test_disconnected(),
+            txn_tx: PollSender::new(tx),
+        };
+        (sender, rx)
     }
 }
 
@@ -109,7 +156,239 @@ where
     } = session;
 
     TpuSender {
-        identity_updated: Arc::new(Mutex::new(identity_updater)),
-        txn_tx: driver_tx_sink,
+        identity_updater,
+        txn_tx: PollSender::new(driver_tx_sink),
+    }
+}
+
+///
+/// A poll-based, non-owning-future variant of [`TpuSender`] for sending transactions.
+///
+/// [`TpuSender::send_txn`] returns a future that borrows `&mut TpuSender` for its
+/// whole lifetime, which is awkward to embed inside a caller's own hand-rolled `Future`/`Sink`
+/// impl (e.g. one that first has to resolve a leader's TPU address, or fan a single transaction
+/// out to several destinations before it can be considered "sent"). `PollTpuSender` exposes the
+/// same underlying reservation as two free-standing methods, [`poll_reserve`] and [`send_item`],
+/// so callers can drive the reserve/send steps manually from inside their own `poll_*` methods
+/// and interleave arbitrary work (address resolution, fan-out, blocklist checks, ...) in between.
+///
+/// It also implements [`futures::Sink`], so it can be used anywhere a `Sink<TpuSenderTxn>` is
+/// expected without the caller having to manage the reserve/send protocol directly.
+///
+/// # Protocol
+///
+/// [`poll_reserve`] and [`send_item`] follow the same contract as [`Sink::poll_ready`] /
+/// [`Sink::start_send`]: a caller **must** call [`poll_reserve`] and get back
+/// `Poll::Ready(Ok(()))` before calling [`send_item`]. Calling [`send_item`] without a prior
+/// successful [`poll_reserve`] is a programmer error and **panics**. Each successful
+/// [`poll_reserve`] reserves capacity for exactly one subsequent [`send_item`] call.
+///
+/// # Cloning
+///
+/// `PollTpuSender` is `Clone` (it wraps a `Clone`-able [`TpuSender`]), but a capacity reservation
+/// obtained via [`poll_reserve`] on one clone is *not* visible to another clone: each clone polls
+/// its own underlying channel sender, so interleaving reserve/send calls across clones of the
+/// same `PollTpuSender` will panic on [`send_item`] just like polling from unrelated tasks would.
+/// Keep the reserve/send pair on a single clone.
+///
+/// [`poll_reserve`]: PollTpuSender::poll_reserve
+/// [`send_item`]: PollTpuSender::send_item
+///
+#[derive(Clone)]
+pub struct PollTpuSender {
+    inner: TpuSender,
+}
+
+impl PollTpuSender {
+    ///
+    /// Wraps an existing [`TpuSender`] to expose its poll-based reserve/send API.
+    ///
+    pub const fn new(inner: TpuSender) -> Self {
+        Self { inner }
+    }
+
+    ///
+    /// Reserves capacity in the underlying transaction channel for one [`send_item`] call.
+    ///
+    /// [`send_item`]: PollTpuSender::send_item
+    ///
+    /// # Returns
+    ///
+    /// - `Poll::Pending` if the channel is currently full. The task is registered to be woken
+    ///   once capacity frees up.
+    /// - `Poll::Ready(Ok(()))` once capacity has been reserved. The caller must follow up with
+    ///   exactly one call to [`send_item`] before calling [`poll_reserve`] again.
+    /// - `Poll::Ready(Err(_))` if the TPU sender task has disconnected. The returned
+    ///   [`TpuSenderError`] carries no transaction (`into_inner()` returns `None`), since none
+    ///   was consumed.
+    ///
+    /// [`poll_reserve`]: PollTpuSender::poll_reserve
+    ///
+    pub fn poll_reserve(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), TpuSenderError>> {
+        let result = ready!(self.inner.txn_tx.poll_reserve(cx));
+        match result {
+            Ok(()) => Poll::Ready(Ok(())),
+            Err(_err) => Poll::Ready(Err(TpuSenderError(None))),
+        }
+    }
+
+    ///
+    /// Sends `txn` into the previously reserved slot in the transaction channel.
+    ///
+    /// # Panics
+    ///
+    /// Panics with `"start_send called before poll_ready returned Ready"` if called without a
+    /// prior [`poll_reserve`] call that returned `Poll::Ready(Ok(()))`. This mirrors the
+    /// [`Sink::start_send`] contract, which forbids calling `start_send` before `poll_ready` has
+    /// signaled readiness.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` if the transaction was handed off to the TPU sender task.
+    /// - `Err(TpuSenderError)` if the TPU sender task disconnected before the send completed. The
+    ///   error carries the transaction back via `into_inner()`, so it isn't silently dropped and
+    ///   can be retried or logged by the caller.
+    ///
+    /// [`poll_reserve`]: PollTpuSender::poll_reserve
+    ///
+    pub fn send_item(&mut self, txn: TpuSenderTxn) -> Result<(), TpuSenderError> {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            self.inner
+                .txn_tx
+                .send_item(txn)
+                .map_err(|e| TpuSenderError(e.into_inner()))
+        }));
+        match result {
+            Ok(result) => result,
+            Err(_) => {
+                panic!("start_send called before poll_ready returned Ready");
+            }
+        }
+    }
+
+    ///
+    /// Updates the identity used by the underlying [`TpuSender`]. See
+    /// [`TpuSender::update_identity`].
+    ///
+    pub fn update_identity(&mut self, new_identity: Keypair) -> UpdateIdentity {
+        self.inner.update_identity(new_identity)
+    }
+}
+
+///
+/// `PollTpuSender` implements [`Sink`] by delegating straight to [`poll_reserve`] and
+/// [`send_item`], so the same reserve-then-send contract applies here: [`start_send`] panics if
+/// called without a preceding [`poll_ready`] that returned `Poll::Ready(Ok(()))`.
+///
+/// Flushing and closing are cheap: the underlying channel has no internal buffering to flush
+/// (every reserved item is already handed to the channel by [`start_send`]), and closing simply
+/// closes the sender half of the channel — it does not wait for the TPU sender task to drain or
+/// shut down.
+///
+/// [`poll_reserve`]: PollTpuSender::poll_reserve
+/// [`send_item`]: PollTpuSender::send_item
+/// [`start_send`]: Sink::start_send
+/// [`poll_ready`]: Sink::poll_ready
+///
+impl Sink<TpuSenderTxn> for PollTpuSender {
+    type Error = TpuSenderError;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.poll_reserve(cx)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: TpuSenderTxn) -> Result<(), Self::Error> {
+        self.send_item(item)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.inner.txn_tx.close();
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, bytes::Bytes, solana_pubkey::Pubkey, solana_signature::Signature};
+
+    fn test_sender(capacity: usize) -> (PollTpuSender, tokio::sync::mpsc::Receiver<TpuSenderTxn>) {
+        let (tpu_sender, rx) = TpuSender::new_test(capacity);
+        (PollTpuSender::new(tpu_sender), rx)
+    }
+
+    fn sample_txn(remote_peer: Pubkey) -> TpuSenderTxn {
+        TpuSenderTxn {
+            tx_sig: Signature::new_unique(),
+            wire: Bytes::from_static(b"wire-bytes"),
+            remote_peer,
+        }
+    }
+
+    #[tokio::test]
+    async fn start_send_delivers_after_poll_ready() {
+        let (mut sender, mut rx) = test_sender(4);
+        let remote_peer = Pubkey::new_unique();
+
+        futures::future::poll_fn(|cx| sender.poll_reserve(cx))
+            .await
+            .expect("poll_ready");
+        sender
+            .send_item(sample_txn(remote_peer))
+            .expect("start_send");
+
+        let received = rx.recv().await.expect("recv");
+        assert_eq!(received.remote_peer, remote_peer);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "start_send called before poll_ready returned Ready")]
+    async fn start_send_panics_without_prior_poll_ready() {
+        let (mut sender, _rx) = test_sender(4);
+        // Never polled `poll_ready`, so there's no reserved permit to send into.
+        let _ = sender.send_item(sample_txn(Pubkey::new_unique()));
+    }
+
+    #[tokio::test]
+    async fn poll_ready_errs_once_receiver_dropped() {
+        let (mut sender, rx) = test_sender(1);
+        drop(rx);
+
+        let result = futures::future::poll_fn(|cx| sender.poll_reserve(cx)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn poll_ready_is_pending_until_capacity_frees_up() {
+        let (mut sender, mut rx) = test_sender(1);
+        let remote_peer = Pubkey::new_unique();
+
+        futures::future::poll_fn(|cx| sender.poll_reserve(cx))
+            .await
+            .expect("poll_ready");
+        sender
+            .send_item(sample_txn(remote_peer))
+            .expect("start_send");
+
+        // The channel's only slot is occupied by the unreceived item above, so a second
+        // reservation must not resolve until the receiver drains it.
+        let mut pending = futures::future::poll_fn(|cx| sender.poll_reserve(cx));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut pending)
+                .await
+                .is_err(),
+            "poll_ready should still be Pending while the channel is full"
+        );
+
+        rx.recv().await.expect("recv");
+        pending
+            .await
+            .expect("poll_ready should resolve once capacity frees up");
     }
 }

--- a/crates/tpu-client/src/slot.rs
+++ b/crates/tpu-client/src/slot.rs
@@ -30,6 +30,14 @@ impl AtomicSlotTracker {
     }
 
     ///
+    /// Builds an [`AtomicSlotTracker`] with a fixed initial slot for integration tests.
+    ///
+    #[cfg(any(test, feature = "intg-testing"))]
+    pub const fn new_for_test(initial_slot: u64) -> Self {
+        Self::new(initial_slot)
+    }
+
+    ///
     /// Load the current slot.
     ///
     /// Returns an error if the slot tracker is poisoned.

--- a/crates/tpu-client/src/yellowstone_grpc/sender.rs
+++ b/crates/tpu-client/src/yellowstone_grpc/sender.rs
@@ -3,7 +3,7 @@ use {
         config::{TpuPortKind, TpuSenderConfig},
         core::{
             Nothing, StakeBasedEvictionStrategy, TpuSenderResponse, TpuSenderResponseCallback,
-            TpuSenderTxn,
+            TpuSenderTxn, UpdateIdentity,
         },
         rpc::{
             schedule::{
@@ -13,7 +13,7 @@ use {
             stake::{RpcValidatorStakeInfoServiceConfig, rpc_validator_stake_info_service},
             tpu_info::{RpcClusterTpuQuicInfoServiceConfig, rpc_cluster_tpu_info_service},
         },
-        sender::{TpuSender, create_base_tpu_client},
+        sender::{PollTpuSender, create_base_tpu_client},
         slot::AtomicSlotTracker,
         yellowstone_grpc::{
             schedule::YellowstoneUpcomingLeader,
@@ -22,6 +22,7 @@ use {
     },
     bytes::Bytes,
     derive_more::Display,
+    futures::future,
     serde::Deserialize,
     solana_client::{
         client_error::ClientError, nonblocking::rpc_client, rpc_client::RpcClientConfig,
@@ -33,9 +34,13 @@ use {
     std::{
         collections::{BTreeSet, HashSet},
         fmt,
+        net::SocketAddr,
         sync::Arc,
+        task::{Context, Poll},
     },
     tokio::sync::mpsc::UnboundedSender,
+    tokio_util::sync::CancellationToken,
+    url::Url,
     yellowstone_grpc_client::{ClientTlsConfig, GeyserGrpcBuilder, GeyserGrpcClient},
 };
 
@@ -66,6 +71,9 @@ pub struct YellowstoneTpuSenderConfig {
     /// Capacity of the internal channel used to send transactions to the TPU sender task.
     ///
     pub channel_capacity: usize,
+    ///
+    /// Endpoints for RPC and gRPC services.
+    pub endpoints: Endpoints,
 }
 
 impl Default for YellowstoneTpuSenderConfig {
@@ -76,6 +84,7 @@ impl Default for YellowstoneTpuSenderConfig {
             schedule: Default::default(),
             stake: Default::default(),
             channel_capacity: DEFAULT_TPU_SENDER_CHANNEL_CAPACITY,
+            endpoints: Endpoints::default(),
         }
     }
 }
@@ -281,7 +290,7 @@ pub enum CreateTpuSenderError {
 /// This struct is cheaply-cloneable and can be shared between threads.
 #[derive(Clone)]
 pub struct YellowstoneTpuSender {
-    base_tpu_sender: TpuSender,
+    base_tpu_sender: PollTpuSender,
     ///
     /// If true, coalesce multiple sends to the same remote tpu socket address into a single send.
     ///
@@ -298,6 +307,19 @@ pub struct YellowstoneTpuSender {
     leader_schedule: ManagedLeaderSchedule,
     leader_tpu_info: Arc<dyn crate::core::LeaderTpuInfoService + Send + Sync>,
     tpu_port_kind: TpuPortKind,
+    _on_drop: Option<Arc<YellowstoneTpuSenderLifecycle>>,
+}
+
+#[derive(Default)]
+struct YellowstoneTpuSenderLifecycle {
+    shutdown: CancellationToken,
+}
+
+impl Drop for YellowstoneTpuSenderLifecycle {
+    fn drop(&mut self) {
+        // This runs once, when the last sender lifecycle Arc is dropped.
+        self.shutdown.cancel();
+    }
 }
 
 ///
@@ -453,6 +475,69 @@ impl Blocklist for ShieldBlockList<'_> {
 
 impl YellowstoneTpuSender {
     ///
+    /// Creates a new [`YellowstoneTpuSender`] with the provided configuration and initial identity.
+    ///
+    /// # Arguments
+    ///
+    /// - `config`: Configuration for the TPU sender [`YellowstoneTpuSenderConfig`], including TPU event-loop, RPC, gRPC, and other settings.
+    /// - `initial_identity`: The initial [`Keypair`] identity to use for sending transactions.
+    ///
+    /// # Notes
+    ///
+    /// They initial [`Keypair`] could be a temporary identity, and you can update it later using [`YellowstoneTpuSender::update_identity`].
+    /// You can generate one easily via [`Keypair::new()`].
+    ///
+    pub async fn connect(
+        config: YellowstoneTpuSenderConfig,
+        initial_identity: Keypair,
+    ) -> Result<YellowstoneTpuSender, CreateTpuSenderError> {
+        let NewYellowstoneTpuSender {
+            sender,
+            related_objects_jh: _,
+        } = create_yellowstone_tpu_sender(config, initial_identity).await?;
+        Ok(sender)
+    }
+
+    ///
+    /// Creates a new [`YellowstoneTpuSender`] with the provided configuration, initial identity, and a callback for TPU responses.
+    ///
+    /// # Arguments
+    ///
+    /// - `config`: Configuration for the TPU sender [`YellowstoneTpuSenderConfig`], including TPU event-loop, RPC, gRPC, and other settings.
+    /// - `initial_identity`: The initial [`Keypair`] identity to use for sending transactions.
+    /// - `callback`: An implementation of [`TpuSenderResponseCallback`] that will be invoked for each response received from the TPU, including successful sends, failures, and dropped transactions.
+    ///
+    pub async fn connect_with_callback(
+        config: YellowstoneTpuSenderConfig,
+        initial_identity: Keypair,
+        callback: impl TpuSenderResponseCallback + 'static,
+    ) -> Result<YellowstoneTpuSender, CreateTpuSenderError> {
+        let NewYellowstoneTpuSender {
+            sender,
+            related_objects_jh: _,
+        } = create_yellowstone_tpu_sender_with_callback(config, initial_identity, callback).await?;
+        Ok(sender)
+    }
+
+    pub fn from_parts(
+        tpu_sender: impl Into<PollTpuSender>,
+        leader_tpu_info: Arc<dyn crate::core::LeaderTpuInfoService + Send + Sync>,
+        managed_leader_schedule: ManagedLeaderSchedule,
+        atomic_slot_tracker: Arc<AtomicSlotTracker>,
+        tpu_port_kind: TpuPortKind,
+    ) -> Self {
+        YellowstoneTpuSender {
+            base_tpu_sender: tpu_sender.into(),
+            leader_tpu_info,
+            atomic_slot_tracker,
+            coalesce_send_many_tpu_port_collision: true,
+            leader_schedule: managed_leader_schedule,
+            tpu_port_kind,
+            _on_drop: None,
+        }
+    }
+
+    ///
     /// Sends a transaction to the specified destinations.
     ///
     /// # Arguments
@@ -501,11 +586,24 @@ impl YellowstoneTpuSender {
                 remote_peer: *dest,
                 wire: wire_txn.clone(),
             };
-            if self.base_tpu_sender.send_txn(tpu_txn).await.is_err() {
+            if future::poll_fn(|cx| self.base_tpu_sender.poll_reserve(cx))
+                .await
+                .is_err()
+            {
                 return Err(SendError {
                     kind: SendErrorKind::Closed,
                     txn: wire_txn,
                 });
+            } else {
+                self.base_tpu_sender
+                    .send_item(tpu_txn)
+                    .map_err(|e| SendError {
+                        kind: SendErrorKind::Closed,
+                        txn: e
+                            .into_inner()
+                            .expect("send_item should return back txn")
+                            .wire,
+                    })?;
             }
         }
         Ok(())
@@ -524,7 +622,7 @@ impl YellowstoneTpuSender {
     ///
     /// The fanout succeed if the sender can schedule at least one send to a leader.
     ///
-    async fn send_txn_fanout_with_blocklist<T, B>(
+    pub async fn send_txn_fanout_with_blocklist<T, B>(
         &mut self,
         sig: Signature,
         txn: T,
@@ -699,8 +797,557 @@ impl YellowstoneTpuSender {
     ///
     /// * `new_identity` - The new identity [`Keypair`] to use.
     ///
-    pub async fn update_identity(&mut self, new_identity: Keypair) {
-        self.base_tpu_sender.update_identity(new_identity).await;
+    pub fn update_identity(&mut self, new_identity: Keypair) -> UpdateIdentity {
+        self.base_tpu_sender.update_identity(new_identity)
+    }
+}
+
+///
+/// Owned, in-progress multi-destination send state for [`PollYellowstoneTpuSender`].
+///
+/// Tracks the same fanout state that [`YellowstoneTpuSender::send_txn_many_dest`] keeps on its
+/// stack (or, for `.await`-based callers, inside its generated future), except here the fields
+/// live inline in [`PollYellowstoneTpuSender`] instead of being borrowed from it, so it never
+/// needs a lifetime parameter.
+///
+struct PollPendingSend {
+    sig: Signature,
+    wire_txn: Bytes,
+    dests: Vec<Pubkey>,
+    next_dest: usize,
+    pending_txn: Option<TpuSenderTxn>,
+}
+
+///
+/// A poll-based equivalent of [`YellowstoneTpuSender`].
+///
+/// [`YellowstoneTpuSender`]'s send methods are `async fn`s, so the futures they return borrow
+/// `&mut self` (and, for [`YellowstoneTpuSender::send_txn_with_shield_policies`], the borrowed
+/// [`ShieldBlockList`] as well) for their entire lifetime. That makes them impossible to store in
+/// a struct alongside the sender they borrow from without either boxing them or resorting to
+/// unsafe self-referential tricks.
+///
+/// [`PollYellowstoneTpuSender`] avoids that entirely: every `start_send_*` method resolves the
+/// destination list *synchronously* (exactly like
+/// [`YellowstoneTpuSender::send_txn_fanout_with_blocklist`] does internally) and stores the
+/// resulting fanout state as owned data inline ([`PollPendingSend`]). Any borrow (like
+/// [`ShieldBlockList`]) only needs to live for the duration of the `start_send_*` call itself.
+///
+/// # Usage
+///
+/// This mirrors the `start_send`/`poll_send` contract used by `futures::Sink`, except a
+/// single [`PollYellowstoneTpuSender`] only ever buffers one in-flight send at a time (there is
+/// no separate readiness check ahead of `start_send_*` -- draining via `poll_send` and being
+/// ready for the next send are the same condition here):
+///
+/// 1. Call one of the `start_send_*` methods to begin a send.
+/// 2. Call [`PollYellowstoneTpuSender::poll_send`] and wait for it to return `Poll::Ready`. This drains
+///    the started send to all of its destinations.
+/// 3. Once flushed, go back to step 1 to start the next send.
+///
+/// Calling a `start_send_*` method before a previously started send has been fully drained via
+/// [`PollYellowstoneTpuSender::poll_send`] is a logic error and will panic.
+///
+pub struct PollYellowstoneTpuSender {
+    sender: YellowstoneTpuSender,
+    pending: Option<PollPendingSend>,
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("disconnected")]
+pub struct PollSendError {
+    signature: Signature,
+    wire_txn: Bytes,
+    dests: Vec<Pubkey>,
+}
+
+impl PollYellowstoneTpuSender {
+    ///
+    /// Wraps an existing [`YellowstoneTpuSender`] in poll-based mode.
+    ///
+    pub const fn new(sender: YellowstoneTpuSender) -> Self {
+        Self {
+            sender,
+            pending: None,
+        }
+    }
+
+    ///
+    /// Drives any in-progress send -- across all of its destinations -- to completion.
+    ///
+    /// Returns `Poll::Ready(Ok(()))` once there is no in-progress send, at which point a
+    /// `start_send_*` method may be called. Must be called (and must return `Poll::Ready`)
+    /// before every `start_send_*` call.
+    ///
+    pub fn poll_send(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), PollSendError>> {
+        loop {
+            let Some(pending) = self.pending.as_mut() else {
+                return Poll::Ready(Ok(()));
+            };
+
+            if pending.pending_txn.is_some() {
+                match self.sender.base_tpu_sender.poll_reserve(cx) {
+                    Poll::Ready(Ok(())) => {
+                        let txn = pending
+                            .pending_txn
+                            .take()
+                            .expect("checked by pending_txn.is_some() above");
+                        if self.sender.base_tpu_sender.send_item(txn).is_err() {
+                            let err = PollSendError {
+                                signature: pending.sig,
+                                wire_txn: pending.wire_txn.clone(),
+                                dests: std::mem::take(&mut pending.dests),
+                            };
+                            self.pending = None;
+                            return Poll::Ready(Err(err));
+                        }
+                        continue;
+                    }
+                    Poll::Ready(Err(_)) => {
+                        let err = PollSendError {
+                            signature: pending.sig,
+                            wire_txn: pending.wire_txn.clone(),
+                            dests: std::mem::take(&mut pending.dests),
+                        };
+                        self.pending = None;
+                        return Poll::Ready(Err(err));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
+
+            if pending.next_dest >= pending.dests.len() {
+                self.pending = None;
+                continue;
+            }
+
+            let remote_peer = pending.dests[pending.next_dest];
+            pending.next_dest += 1;
+            pending.pending_txn = Some(TpuSenderTxn {
+                tx_sig: pending.sig,
+                remote_peer,
+                wire: pending.wire_txn.clone(),
+            });
+        }
+    }
+
+    fn assert_ready_for_start_send(&self) {
+        assert!(
+            self.pending.is_none(),
+            "PollYellowstoneTpuSender::start_send_* called before poll_send returned Poll::Ready"
+        );
+    }
+
+    ///
+    /// Poll-based equivalent of [`YellowstoneTpuSender::send_txn_many_dest`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if called before a previously started send was fully drained via
+    /// [`PollYellowstoneTpuSender::poll_send`].
+    ///
+    pub fn start_send_txn_many_dest<T>(
+        &mut self,
+        sig: Signature,
+        txn: T,
+        dests: &[Pubkey],
+    ) -> Result<(), SendError>
+    where
+        T: AsRef<[u8]> + Send + 'static,
+    {
+        self.assert_ready_for_start_send();
+
+        let wire_txn = Bytes::from_owner(txn);
+        if dests.is_empty() {
+            return Ok(());
+        }
+
+        let mut selected_dests = Vec::with_capacity(dests.len());
+        let mut dest_addr_vec = Vec::<SocketAddr>::with_capacity(dests.len());
+        for dest in dests {
+            if let Some(addr) = self
+                .sender
+                .leader_tpu_info
+                .get_quic_dest_addr(dest, self.sender.tpu_port_kind)
+            {
+                if self.sender.coalesce_send_many_tpu_port_collision
+                    && dest_addr_vec.contains(&addr)
+                {
+                    continue;
+                }
+                dest_addr_vec.push(addr);
+            }
+            selected_dests.push(*dest);
+        }
+
+        self.pending = Some(PollPendingSend {
+            sig,
+            wire_txn,
+            dests: selected_dests,
+            next_dest: 0,
+            pending_txn: None,
+        });
+        Ok(())
+    }
+
+    ///
+    /// Poll-based equivalent of [`YellowstoneTpuSender::send_txn_with_blocklist`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if called before a previously started send was fully drained via
+    /// [`PollYellowstoneTpuSender::poll_send`].
+    ///
+    pub fn start_send_txn_with_blocklist<T, B>(
+        &mut self,
+        sig: Signature,
+        txn: T,
+        blocklist: Option<B>,
+    ) -> Result<(), SendError>
+    where
+        T: AsRef<[u8]> + Send + 'static,
+        B: Blocklist,
+    {
+        self.assert_ready_for_start_send();
+
+        let wire_txn = Bytes::from_owner(txn);
+        let current_slot = match self.sender.atomic_slot_tracker.load() {
+            Ok(slot) => slot,
+            Err(_) => {
+                return Err(SendError {
+                    kind: SendErrorKind::SlotTrackerDisconnected,
+                    txn: wire_txn,
+                });
+            }
+        };
+        let reminder = current_slot % 4;
+        let floor_leader_boundary = current_slot.saturating_sub(reminder);
+        let n = if reminder >= 2 { 2 } else { 1 };
+
+        let mut blocked_cnt = 0;
+        let result = (0..n)
+            .map(|i| floor_leader_boundary + (i * 4) as u64)
+            .map(|leader_slot_boundary| {
+                self.sender.leader_schedule.get_leader(leader_slot_boundary)
+            })
+            .filter_map(|res| match res {
+                Ok(None) => {
+                    panic!("unknown leader for slot boundary {floor_leader_boundary}");
+                }
+                Ok(Some(leader)) => {
+                    if let Some(blocklist) = &blocklist {
+                        if blocklist.is_blocked(&leader) {
+                            blocked_cnt += 1;
+                            None
+                        } else {
+                            Some(Ok(leader))
+                        }
+                    } else {
+                        Some(Ok(leader))
+                    }
+                }
+                Err(_) => Some(Err(SendErrorKind::ManagedLeaderScheduleDisconnected)),
+            })
+            .collect::<Result<Vec<_>, SendErrorKind>>();
+
+        match result {
+            Ok(leaders) => {
+                if leaders.is_empty() && blocked_cnt > 0 {
+                    Err(SendError {
+                        kind: SendErrorKind::RemotePeerBlocked,
+                        txn: wire_txn,
+                    })
+                } else {
+                    self.start_send_txn_many_dest(sig, wire_txn, &leaders)
+                }
+            }
+            Err(err_kind) => Err(SendError {
+                kind: err_kind,
+                txn: wire_txn,
+            }),
+        }
+    }
+
+    ///
+    /// Poll-based equivalent of [`YellowstoneTpuSender::send_txn`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if called before a previously started send was fully drained via
+    /// [`PollYellowstoneTpuSender::poll_send`].
+    ///
+    pub fn start_send_txn<T>(&mut self, sig: Signature, txn: T) -> Result<(), SendError>
+    where
+        T: AsRef<[u8]> + Send + 'static,
+    {
+        self.start_send_txn_with_blocklist(sig, txn, Some(NoBlocklist))
+    }
+
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(feature = "shield", doc = "only if `shield` feature-flag is enabled"))
+    )]
+    #[cfg(feature = "shield")]
+    ///
+    /// Poll-based equivalent of [`YellowstoneTpuSender::send_txn_with_shield_policies`].
+    ///
+    /// The [`ShieldBlockList`] borrow only needs to be valid for the duration of this call: it is
+    /// used synchronously to resolve the upcoming leaders into a destination list, which is then
+    /// owned by this [`PollYellowstoneTpuSender`] for the rest of the send.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called before a previously started send was fully drained via
+    /// [`PollYellowstoneTpuSender::poll_send`].
+    ///
+    pub fn start_send_txn_with_shield_policies<T>(
+        &mut self,
+        sig: Signature,
+        txn: T,
+        shield: ShieldBlockList<'_>,
+    ) -> Result<(), SendError>
+    where
+        T: AsRef<[u8]> + Send + 'static,
+    {
+        self.start_send_txn_with_blocklist(sig, txn, Some(shield))
+    }
+
+    ///
+    /// Updates the identity keypair used by the underlying [`YellowstoneTpuSender`].
+    ///
+    pub fn update_identity(&mut self, new_identity: Keypair) -> UpdateIdentity {
+        self.sender.update_identity(new_identity)
+    }
+
+    ///
+    /// Unwraps the underlying [`YellowstoneTpuSender`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is a send in-progress that hasn't been drained via
+    /// [`PollYellowstoneTpuSender::poll_send`].
+    ///
+    pub fn into_inner(self) -> YellowstoneTpuSender {
+        assert!(
+            self.pending.is_none(),
+            "PollYellowstoneTpuSender::into_inner called with a send in-progress"
+        );
+        self.sender
+    }
+}
+
+impl From<YellowstoneTpuSender> for PollYellowstoneTpuSender {
+    fn from(sender: YellowstoneTpuSender) -> Self {
+        Self::new(sender)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::core::LeaderTpuInfoService, std::collections::HashMap};
+
+    struct FakeLeaderTpuInfo(HashMap<Pubkey, SocketAddr>);
+
+    impl LeaderTpuInfoService for FakeLeaderTpuInfo {
+        fn get_quic_tpu_socket_addr(&self, leader_pubkey: &Pubkey) -> Option<SocketAddr> {
+            self.0.get(leader_pubkey).copied()
+        }
+
+        fn get_quic_tpu_fwd_socket_addr(&self, leader_pubkey: &Pubkey) -> Option<SocketAddr> {
+            self.0.get(leader_pubkey).copied()
+        }
+    }
+
+    /// Builds a [`PollYellowstoneTpuSender`] with a fake leader-tpu-info map and a fixed,
+    /// single-epoch leader schedule, for tests that don't need real RPC/QUIC services.
+    fn test_yellowstone_sender(
+        addrs: HashMap<Pubkey, SocketAddr>,
+        coalesce: bool,
+        current_slot: u64,
+        schedule: Vec<Pubkey>,
+    ) -> (
+        PollYellowstoneTpuSender,
+        tokio::sync::mpsc::Receiver<TpuSenderTxn>,
+    ) {
+        let (tpu_sender, rx) = crate::sender::TpuSender::new_test(8);
+        let sender = YellowstoneTpuSender {
+            base_tpu_sender: PollTpuSender::new(tpu_sender),
+            coalesce_send_many_tpu_port_collision: coalesce,
+            atomic_slot_tracker: Arc::new(AtomicSlotTracker::new(current_slot)),
+            leader_schedule: ManagedLeaderSchedule::new_for_test(0, schedule),
+            leader_tpu_info: Arc::new(FakeLeaderTpuInfo(addrs)),
+            tpu_port_kind: TpuPortKind::Forwards,
+            _on_drop: Some(Arc::new(YellowstoneTpuSenderLifecycle::default())),
+        };
+        (PollYellowstoneTpuSender::new(sender), rx)
+    }
+
+    #[tokio::test]
+    async fn start_send_txn_many_dest_fans_out_to_all_destinations() {
+        let peer1 = Pubkey::new_unique();
+        let peer2 = Pubkey::new_unique();
+        let addrs = HashMap::from([
+            (peer1, "127.0.0.1:8001".parse().unwrap()),
+            (peer2, "127.0.0.1:8002".parse().unwrap()),
+        ]);
+        let (mut sender, mut rx) = test_yellowstone_sender(addrs, true, 0, vec![]);
+
+        sender
+            .start_send_txn_many_dest(
+                Signature::new_unique(),
+                Bytes::from_static(b"wire"),
+                &[peer1, peer2],
+            )
+            .expect("start_send_txn_many_dest");
+
+        futures::future::poll_fn(|cx| sender.poll_send(cx))
+            .await
+            .expect("poll_send");
+
+        let mut received = vec![
+            rx.recv().await.expect("recv 1").remote_peer,
+            rx.recv().await.expect("recv 2").remote_peer,
+        ];
+        received.sort();
+        let mut expected = vec![peer1, peer2];
+        expected.sort();
+        assert_eq!(received, expected);
+    }
+
+    #[tokio::test]
+    async fn start_send_txn_many_dest_with_empty_dests_is_immediately_ready() {
+        let (mut sender, _rx) = test_yellowstone_sender(HashMap::new(), true, 0, vec![]);
+
+        sender
+            .start_send_txn_many_dest(Signature::new_unique(), Bytes::from_static(b"wire"), &[])
+            .expect("start_send_txn_many_dest");
+
+        // No destinations were resolved, so there's nothing to drain: poll_send should
+        // resolve on its very first poll.
+        futures::future::poll_fn(|cx| sender.poll_send(cx))
+            .await
+            .expect("poll_send");
+    }
+
+    #[tokio::test]
+    async fn start_send_txn_many_dest_coalesces_same_address_destinations() {
+        let peer1 = Pubkey::new_unique();
+        let peer2 = Pubkey::new_unique();
+        // Both peers share the same TPU socket address (e.g. behind a proxy).
+        let shared_addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
+        let addrs = HashMap::from([(peer1, shared_addr), (peer2, shared_addr)]);
+        let (mut sender, mut rx) = test_yellowstone_sender(addrs, true, 0, vec![]);
+
+        sender
+            .start_send_txn_many_dest(
+                Signature::new_unique(),
+                Bytes::from_static(b"wire"),
+                &[peer1, peer2],
+            )
+            .expect("start_send_txn_many_dest");
+
+        futures::future::poll_fn(|cx| sender.poll_send(cx))
+            .await
+            .expect("poll_send");
+
+        let received = rx
+            .recv()
+            .await
+            .expect("expected exactly one coalesced send");
+        assert_eq!(received.remote_peer, peer1);
+        assert!(
+            rx.try_recv().is_err(),
+            "the second destination should have been coalesced away"
+        );
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "start_send_* called before poll_send returned Poll::Ready")]
+    async fn start_send_panics_if_previous_send_not_drained() {
+        let peer = Pubkey::new_unique();
+        let addrs = HashMap::from([(peer, "127.0.0.1:9100".parse().unwrap())]);
+        let (mut sender, _rx) = test_yellowstone_sender(addrs, true, 0, vec![]);
+
+        sender
+            .start_send_txn_many_dest(
+                Signature::new_unique(),
+                Bytes::from_static(b"wire"),
+                &[peer],
+            )
+            .expect("first start_send_txn_many_dest");
+        // Second call before draining the first via `poll_send` must panic.
+        let _ = sender.start_send_txn_many_dest(
+            Signature::new_unique(),
+            Bytes::from_static(b"wire"),
+            &[peer],
+        );
+    }
+
+    #[tokio::test]
+    async fn start_send_txn_with_blocklist_returns_remote_peer_blocked_when_all_blocked() {
+        let leader = Pubkey::new_unique();
+        let addrs = HashMap::from([(leader, "127.0.0.1:9300".parse().unwrap())]);
+        // `current_slot = 0` resolves to a single leader boundary (slot 0), which the
+        // fixed schedule maps to `leader`.
+        let (mut sender, _rx) = test_yellowstone_sender(addrs, true, 0, vec![leader]);
+
+        let err = sender
+            .start_send_txn_with_blocklist(
+                Signature::new_unique(),
+                Bytes::from_static(b"wire"),
+                Some(vec![leader]),
+            )
+            .expect_err("expected the only resolved leader to be blocked");
+
+        assert!(matches!(err.kind, SendErrorKind::RemotePeerBlocked));
+    }
+
+    #[tokio::test]
+    async fn start_send_txn_with_blocklist_sends_to_unblocked_leader() {
+        let leader = Pubkey::new_unique();
+        let other = Pubkey::new_unique();
+        let addrs = HashMap::from([(leader, "127.0.0.1:9301".parse().unwrap())]);
+        let (mut sender, mut rx) = test_yellowstone_sender(addrs, true, 0, vec![leader]);
+
+        sender
+            .start_send_txn_with_blocklist(
+                Signature::new_unique(),
+                Bytes::from_static(b"wire"),
+                Some(vec![other]), // blocklist doesn't include `leader`
+            )
+            .expect("start_send_txn_with_blocklist");
+
+        futures::future::poll_fn(|cx| sender.poll_send(cx))
+            .await
+            .expect("poll_send");
+
+        let received = rx.recv().await.expect("recv");
+        assert_eq!(received.remote_peer, leader);
+    }
+
+    #[test]
+    fn drop_of_last_sender_cancels_lifecycle_shutdown() {
+        let (sender, _rx) = test_yellowstone_sender(HashMap::new(), true, 0, vec![]);
+        let sender = sender.into_inner();
+        let shutdown = sender
+            ._on_drop
+            .as_ref()
+            .expect("lifecycle")
+            .shutdown
+            .clone();
+        let sender2 = sender.clone();
+
+        drop(sender);
+        assert!(
+            !shutdown.is_cancelled(),
+            "dropping one clone must not cancel while another clone exists"
+        );
+
+        drop(sender2);
+        assert!(
+            shutdown.is_cancelled(),
+            "dropping the last sender must cancel lifecycle shutdown"
+        );
     }
 }
 
@@ -799,13 +1446,16 @@ where
 
     tracing::debug!("created base tpu sender");
 
+    let lifecycle = Arc::new(YellowstoneTpuSenderLifecycle::default());
+
     let sender = YellowstoneTpuSender {
-        base_tpu_sender,
+        base_tpu_sender: PollTpuSender::new(base_tpu_sender),
         atomic_slot_tracker,
         coalesce_send_many_tpu_port_collision: true,
         leader_schedule: managed_leader_schedule,
         leader_tpu_info: Arc::clone(&tpu_info_service),
         tpu_port_kind,
+        _on_drop: Some(Arc::clone(&lifecycle)),
     };
 
     let handles = vec![
@@ -823,20 +1473,50 @@ where
 
     Ok(NewYellowstoneTpuSender {
         sender,
-        related_objects_jh: tokio::spawn(yellowstone_tpu_deps_overseer(handle_name_vec, handles)),
+        related_objects_jh: tokio::spawn(yellowstone_tpu_deps_overseer(
+            handle_name_vec,
+            handles,
+            lifecycle.shutdown.clone(),
+        )),
     })
 }
 
 ///
 /// Endpoints required to connect to Yellowstone services.
 ///
+/// This struct is embedded in [`YellowstoneTpuSenderConfig`] (see for more details).
+///
+#[derive(Deserialize, Clone, Debug)]
 pub struct Endpoints {
     /// RPC endpoint URL.
-    pub rpc: String,
+    #[serde(default = "Endpoints::default_rpc_url")]
+    pub rpc: Url,
     /// gRPC endpoint URL.
-    pub grpc: String,
+    #[serde(default = "Endpoints::default_grpc_url")]
+    pub grpc: Url,
     /// Optional X-Token for authentication.
+    #[serde(default)]
     pub grpc_x_token: Option<String>,
+}
+
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self {
+            rpc: Self::default_rpc_url(),
+            grpc: Self::default_grpc_url(),
+            grpc_x_token: None,
+        }
+    }
+}
+
+impl Endpoints {
+    fn default_rpc_url() -> Url {
+        Url::parse("http://localhost:8899").unwrap()
+    }
+
+    fn default_grpc_url() -> Url {
+        Url::parse("http://localhost:10000").unwrap()
+    }
 }
 
 ///
@@ -847,7 +1527,6 @@ pub struct Endpoints {
 pub async fn create_yellowstone_tpu_sender_with_callback<CB>(
     config: YellowstoneTpuSenderConfig,
     initial_identity: Keypair,
-    endpoints: Endpoints,
     callback: CB,
 ) -> Result<NewYellowstoneTpuSender, CreateTpuSenderError>
 where
@@ -857,7 +1536,7 @@ where
         rpc,
         grpc,
         grpc_x_token,
-    } = endpoints;
+    } = config.endpoints.clone();
 
     let http_sender = HttpSender::new(rpc);
     let rpc_sender = RetryRpcSender::new(http_sender, Default::default());
@@ -870,7 +1549,7 @@ where
         },
     ));
 
-    let grpc_client = GeyserGrpcBuilder::from_shared(grpc)
+    let grpc_client = GeyserGrpcBuilder::from_shared(grpc.as_str().to_owned())
         .expect("from_shared")
         .x_token(grpc_x_token)
         .expect("x-token")
@@ -895,32 +1574,50 @@ where
 pub async fn create_yellowstone_tpu_sender(
     config: YellowstoneTpuSenderConfig,
     initial_identity: Keypair,
-    endpoints: Endpoints,
 ) -> Result<NewYellowstoneTpuSender, CreateTpuSenderError> {
-    create_yellowstone_tpu_sender_with_callback(config, initial_identity, endpoints, Nothing).await
+    create_yellowstone_tpu_sender_with_callback(config, initial_identity, Nothing).await
 }
 
 async fn yellowstone_tpu_deps_overseer(
     handle_name_vec: Vec<&'static str>,
     handles: Vec<tokio::task::JoinHandle<()>>,
+    shutdown: CancellationToken,
 ) {
-    // Wait for the first task to finish
-
-    let (finished_handle, i, rest) = futures::future::select_all(handles).await;
-    if finished_handle.is_err() {
-        tracing::error!(
-            "Yellowstone TPU sender dependency task '{}' has failed with {finished_handle:?}",
-            handle_name_vec.get(i).unwrap_or(&"unknown")
-        );
-    } else {
-        tracing::warn!(
-            "Yellowstone TPU sender dependency task '{}' has finished",
-            handle_name_vec.get(i).unwrap_or(&"unknown")
-        );
+    if handles.is_empty() {
+        return;
     }
 
-    // Abort the rest
-    rest.into_iter().for_each(|jh| jh.abort());
+    let abort_handles = handles
+        .iter()
+        .map(|jh| jh.abort_handle())
+        .collect::<Vec<_>>();
+
+    // Wait for the first task to finish
+    tokio::select! {
+        _ = shutdown.cancelled() => {
+            tracing::info!(
+                "Yellowstone TPU sender handles all dropped, aborting dependency tasks"
+            );
+            abort_handles.iter().for_each(|h| h.abort());
+        }
+        result = futures::future::select_all(handles) => {
+            let (finished_handle, i, rest) = result;
+            if finished_handle.is_err() {
+                tracing::error!(
+                    "Yellowstone TPU sender dependency task '{}' has failed with {finished_handle:?}",
+                    handle_name_vec.get(i).unwrap_or(&"unknown")
+                );
+            } else {
+                tracing::warn!(
+                    "Yellowstone TPU sender dependency task '{}' has finished",
+                    handle_name_vec.get(i).unwrap_or(&"unknown")
+                );
+            }
+
+            // Abort the rest
+            rest.into_iter().for_each(|jh| jh.abort());
+        }
+    }
 }
 
 impl TpuSenderResponseCallback for UnboundedSender<TpuSenderResponse> {

--- a/crates/tpu-client/tests/test_quic_gateway.rs
+++ b/crates/tpu-client/tests/test_quic_gateway.rs
@@ -477,7 +477,8 @@ async fn it_should_update_gatway_identity() {
 
     identity_updater
         .update_identity(gateway_identity2.insecure_clone())
-        .await;
+        .await
+        .unwrap();
 
     let txn = TpuSenderTxn::from_owned(
         Signature::new_unique(),
@@ -1259,7 +1260,8 @@ async fn it_should_support_multiplexed_connection() {
 
     identity_updater
         .update_identity(tpu_sender_identity2.insecure_clone())
-        .await;
+        .await
+        .unwrap();
 
     let txn_remote_peer1 = TpuSenderTxn::from_owned(
         Signature::new_unique(),

--- a/crates/tpu-client/tests/test_yellowstone_tpu_sender.rs
+++ b/crates/tpu-client/tests/test_yellowstone_tpu_sender.rs
@@ -1,0 +1,410 @@
+#![cfg(feature = "intg-testing")]
+
+mod testkit;
+
+use {
+    crate::testkit::{build_validator_quic_tpu_endpoint, generate_random_local_addr},
+    bytes::Bytes,
+    quinn::ConnectionError,
+    solana_keypair::Keypair,
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
+    solana_signer::Signer,
+    std::{
+        array,
+        collections::HashMap,
+        net::SocketAddr,
+        sync::{Arc, Mutex, RwLock},
+        time::Duration,
+    },
+    tokio::{
+        sync::mpsc,
+        task::{JoinHandle, JoinSet},
+    },
+    x509_parser::{asn1_rs::FromDer, certificate::X509Certificate, public_key::PublicKey},
+    yellowstone_jet_tpu_client::{
+        config::{TpuPortKind, TpuSenderConfig},
+        core::{
+            IgnorantLeaderPredictor, LeaderTpuInfoService, Nothing, StakeBasedEvictionStrategy,
+            ValidatorStakeInfoService,
+        },
+        rpc::schedule::ManagedLeaderSchedule,
+        sender::create_base_tpu_client,
+        slot::AtomicSlotTracker,
+        yellowstone_grpc::sender::YellowstoneTpuSender,
+    },
+};
+
+#[derive(Clone)]
+struct MockStakeInfoMap {
+    stake_map: Arc<Mutex<HashMap<Pubkey, u64>>>,
+}
+
+impl MockStakeInfoMap {
+    fn constant<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = (Pubkey, u64)>,
+    {
+        let stake_map = Arc::new(Mutex::new(HashMap::from_iter(iter)));
+        Self { stake_map }
+    }
+}
+
+impl ValidatorStakeInfoService for MockStakeInfoMap {
+    fn get_stake_info(&self, validator_pubkey: &Pubkey) -> Option<u64> {
+        self.stake_map
+            .lock()
+            .expect("stake map lock")
+            .get(validator_pubkey)
+            .cloned()
+    }
+}
+
+#[derive(Clone)]
+struct FakeLeaderTpuInfoService {
+    shared: Arc<RwLock<HashMap<Pubkey, SocketAddr>>>,
+}
+
+impl FakeLeaderTpuInfoService {
+    fn from_iter<IT>(it: IT) -> Self
+    where
+        IT: IntoIterator<Item = (Pubkey, SocketAddr)>,
+    {
+        let shared = Arc::new(RwLock::new(HashMap::from_iter(it)));
+        Self { shared }
+    }
+}
+
+impl LeaderTpuInfoService for FakeLeaderTpuInfoService {
+    fn get_quic_tpu_socket_addr(&self, leader_pubkey: &Pubkey) -> Option<SocketAddr> {
+        self.shared
+            .read()
+            .expect("read lock")
+            .get(leader_pubkey)
+            .cloned()
+    }
+
+    fn get_quic_tpu_fwd_socket_addr(&self, leader_pubkey: &Pubkey) -> Option<SocketAddr> {
+        self.shared
+            .read()
+            .expect("read lock")
+            .get(leader_pubkey)
+            .cloned()
+    }
+}
+
+struct MockedRemoteValidator;
+
+struct InterceptedTxn {
+    from: Pubkey,
+    connection_id: usize,
+    data: Vec<u8>,
+}
+
+fn get_remote_pubkey_from_quic_connection(conn: &quinn::Connection) -> Option<Pubkey> {
+    conn.peer_identity()?
+        .downcast::<Vec<rustls::pki_types::CertificateDer>>()
+        .ok()
+        .filter(|certs| certs.len() == 1)?
+        .first()
+        .and_then(get_pubkey_from_tls_certificate)
+}
+
+fn get_pubkey_from_tls_certificate(der_cert: &rustls::pki_types::CertificateDer) -> Option<Pubkey> {
+    let (_, cert) = X509Certificate::from_der(der_cert.as_ref()).ok()?;
+    match cert.public_key().parsed().ok()? {
+        PublicKey::Unknown(key) => Pubkey::try_from(key).ok(),
+        _ => None,
+    }
+}
+
+impl MockedRemoteValidator {
+    fn spawn(kp: Keypair, addr: SocketAddr) -> (mpsc::Receiver<InterceptedTxn>, JoinHandle<()>) {
+        let endpoint = build_validator_quic_tpu_endpoint(&kp, addr);
+        let (client_tx, client_rx) = mpsc::channel(100);
+        let client_tx2 = client_tx.clone();
+
+        let rx_server_handle = tokio::spawn(async move {
+            let mut connection_set: JoinSet<Result<(), ConnectionError>> = JoinSet::new();
+            let mut connection_id: usize = 0;
+
+            loop {
+                let connecting = tokio::select! {
+                    result = endpoint.accept() => {
+                        result.expect("accept connection")
+                    }
+                    Some(result) = connection_set.join_next() => {
+                        let _ = result.expect("join next");
+                        continue;
+                    }
+                };
+
+                let new_connection_id = connection_id;
+                let conn = connecting.await.expect("quinn connection");
+                connection_id += 1;
+                let remote_key =
+                    get_remote_pubkey_from_quic_connection(&conn).expect("get remote pubkey");
+
+                let client_tx = client_tx2.clone();
+                connection_set.spawn(async move {
+                    loop {
+                        let mut rx = conn.accept_uni().await?;
+                        let mut chunks: [Bytes; 4] = array::from_fn(|_| Bytes::new());
+                        let mut total_chunks_read = 0;
+
+                        while let Some(n_chunk) =
+                            rx.read_chunks(&mut chunks).await.expect("read chunks")
+                        {
+                            total_chunks_read += n_chunk;
+                            assert!(total_chunks_read <= 4, "total_chunks_read > 4");
+                        }
+
+                        let combined = chunks.iter().fold(vec![], |mut acc, chunk| {
+                            acc.extend_from_slice(chunk);
+                            acc
+                        });
+
+                        drop(rx);
+                        let req = InterceptedTxn {
+                            from: remote_key,
+                            connection_id: new_connection_id,
+                            data: combined,
+                        };
+                        client_tx.send(req).await.expect("send");
+                    }
+                });
+            }
+        });
+
+        (client_rx, rx_server_handle)
+    }
+}
+
+async fn build_sender_from_parts(
+    gateway_kp: Keypair,
+    leader_tpu_info: Arc<dyn LeaderTpuInfoService + Send + Sync>,
+    schedule: Vec<Pubkey>,
+    current_slot: u64,
+) -> YellowstoneTpuSender {
+    let stake_info_map = MockStakeInfoMap::constant([(gateway_kp.pubkey(), 1_000)]);
+
+    let base_tpu_sender = create_base_tpu_client(
+        TpuSenderConfig {
+            max_connection_attempts: 1,
+            ..Default::default()
+        },
+        gateway_kp,
+        Arc::clone(&leader_tpu_info),
+        Arc::new(stake_info_map),
+        Arc::new(StakeBasedEvictionStrategy::default()),
+        Arc::new(IgnorantLeaderPredictor),
+        Option::<Nothing>::None,
+        128,
+    )
+    .await;
+
+    YellowstoneTpuSender::from_parts(
+        base_tpu_sender,
+        leader_tpu_info,
+        ManagedLeaderSchedule::new_for_test(0, schedule),
+        Arc::new(AtomicSlotTracker::new_for_test(current_slot)),
+        TpuPortKind::Forwards,
+    )
+}
+
+#[tokio::test]
+async fn from_parts_send_txn_many_dest_should_land_properly() {
+    let remote_addr = generate_random_local_addr();
+    let remote_identity = Keypair::new();
+
+    let gateway_kp = Keypair::new();
+    let leader_tpu_info = Arc::new(FakeLeaderTpuInfoService::from_iter([(
+        remote_identity.pubkey(),
+        remote_addr,
+    )])) as Arc<dyn LeaderTpuInfoService + Send + Sync>;
+
+    let mut sender =
+        build_sender_from_parts(gateway_kp.insecure_clone(), leader_tpu_info, vec![], 0).await;
+
+    let (mut client_rx, _rx_server_handle) =
+        MockedRemoteValidator::spawn(remote_identity.insecure_clone(), remote_addr);
+
+    sender
+        .send_txn_many_dest(
+            Signature::new_unique(),
+            "helloworld".as_bytes().to_vec(),
+            &[remote_identity.pubkey()],
+        )
+        .await
+        .expect("send_txn_many_dest");
+
+    let spy_req = tokio::time::timeout(Duration::from_secs(5), client_rx.recv())
+        .await
+        .expect("timeout waiting remote receive")
+        .expect("recv");
+
+    let msg = String::from_utf8(spy_req.data).expect("utf8");
+    assert_eq!(msg, "helloworld");
+    assert_eq!(spy_req.from, gateway_kp.pubkey());
+}
+
+#[tokio::test]
+async fn from_parts_sending_multiple_tx_to_same_peer_should_reuse_connection() {
+    let remote_addr = generate_random_local_addr();
+    let remote_identity = Keypair::new();
+
+    let gateway_kp = Keypair::new();
+    let leader_tpu_info = Arc::new(FakeLeaderTpuInfoService::from_iter([(
+        remote_identity.pubkey(),
+        remote_addr,
+    )])) as Arc<dyn LeaderTpuInfoService + Send + Sync>;
+
+    let mut sender =
+        build_sender_from_parts(gateway_kp.insecure_clone(), leader_tpu_info, vec![], 0).await;
+
+    let (mut client_rx, _rx_server_handle) =
+        MockedRemoteValidator::spawn(remote_identity.insecure_clone(), remote_addr);
+
+    const MAX_TX: usize = 5;
+    for i in 0..MAX_TX {
+        sender
+            .send_txn_many_dest(
+                Signature::new_unique(),
+                format!("helloworld{i}").as_bytes().to_vec(),
+                &[remote_identity.pubkey()],
+            )
+            .await
+            .expect("send_txn_many_dest");
+    }
+
+    let mut connection_ids = Vec::with_capacity(MAX_TX);
+    for i in 0..MAX_TX {
+        let spy_req = tokio::time::timeout(Duration::from_secs(5), client_rx.recv())
+            .await
+            .expect("timeout waiting remote receive")
+            .expect("recv");
+
+        let msg = String::from_utf8(spy_req.data).expect("utf8");
+        assert_eq!(msg, format!("helloworld{i}"));
+        connection_ids.push(spy_req.connection_id);
+    }
+
+    let first = connection_ids
+        .first()
+        .copied()
+        .expect("first connection id");
+    assert!(
+        connection_ids.iter().all(|id| *id == first),
+        "expected all txs to reuse the same connection, got {connection_ids:?}"
+    );
+}
+
+#[tokio::test]
+async fn from_parts_send_txn_should_follow_managed_schedule() {
+    let leader_addr = generate_random_local_addr();
+    let non_leader_addr = generate_random_local_addr();
+
+    let leader_identity = Keypair::new();
+    let non_leader_identity = Keypair::new();
+
+    let gateway_kp = Keypair::new();
+    let leader_tpu_info = Arc::new(FakeLeaderTpuInfoService::from_iter([
+        (leader_identity.pubkey(), leader_addr),
+        (non_leader_identity.pubkey(), non_leader_addr),
+    ])) as Arc<dyn LeaderTpuInfoService + Send + Sync>;
+
+    let mut sender = build_sender_from_parts(
+        gateway_kp.insecure_clone(),
+        leader_tpu_info,
+        vec![leader_identity.pubkey()],
+        0,
+    )
+    .await;
+
+    let (mut leader_rx, _leader_jh) =
+        MockedRemoteValidator::spawn(leader_identity.insecure_clone(), leader_addr);
+    let (mut non_leader_rx, _non_leader_jh) =
+        MockedRemoteValidator::spawn(non_leader_identity.insecure_clone(), non_leader_addr);
+
+    sender
+        .send_txn(Signature::new_unique(), "fanout".as_bytes().to_vec())
+        .await
+        .expect("send_txn");
+
+    let leader_req = tokio::time::timeout(Duration::from_secs(5), leader_rx.recv())
+        .await
+        .expect("timeout waiting leader receive")
+        .expect("leader recv");
+
+    assert_eq!(String::from_utf8(leader_req.data).expect("utf8"), "fanout");
+
+    let non_leader_received =
+        tokio::time::timeout(Duration::from_millis(400), non_leader_rx.recv()).await;
+    assert!(
+        non_leader_received.is_err(),
+        "non-leader should not receive transaction"
+    );
+}
+
+#[tokio::test]
+async fn from_parts_should_support_identity_update() {
+    let remote_addr = generate_random_local_addr();
+    let remote_identity = Keypair::new();
+
+    let gateway_identity_1 = Keypair::new();
+    let gateway_identity_2 = Keypair::new();
+
+    let leader_tpu_info = Arc::new(FakeLeaderTpuInfoService::from_iter([(
+        remote_identity.pubkey(),
+        remote_addr,
+    )])) as Arc<dyn LeaderTpuInfoService + Send + Sync>;
+
+    let mut sender = build_sender_from_parts(
+        gateway_identity_1.insecure_clone(),
+        leader_tpu_info,
+        vec![],
+        0,
+    )
+    .await;
+
+    let (mut client_rx, _rx_server_handle) =
+        MockedRemoteValidator::spawn(remote_identity.insecure_clone(), remote_addr);
+
+    sender
+        .send_txn_many_dest(
+            Signature::new_unique(),
+            "before-update".as_bytes().to_vec(),
+            &[remote_identity.pubkey()],
+        )
+        .await
+        .expect("send before update");
+
+    let first_req = tokio::time::timeout(Duration::from_secs(5), client_rx.recv())
+        .await
+        .expect("timeout waiting first tx")
+        .expect("first recv");
+
+    assert_eq!(first_req.from, gateway_identity_1.pubkey());
+
+    sender
+        .update_identity(gateway_identity_2.insecure_clone())
+        .await
+        .expect("update identity");
+
+    sender
+        .send_txn_many_dest(
+            Signature::new_unique(),
+            "after-update".as_bytes().to_vec(),
+            &[remote_identity.pubkey()],
+        )
+        .await
+        .expect("send after update");
+
+    let second_req = tokio::time::timeout(Duration::from_secs(5), client_rx.recv())
+        .await
+        .expect("timeout waiting second tx")
+        .expect("second recv");
+
+    assert_eq!(second_req.from, gateway_identity_2.pubkey());
+    assert_ne!(first_req.from, second_req.from);
+}


### PR DESCRIPTION
# jet-tpu-sender lib changes

Introduced a new poll-oriented API for `TpuSender` and `YellowstoneTpuSender` to allow better integration with Rust's `Future`/`Sink`/`Stream` and existing future extension.

Added quicker `YellowstoneTpuSender::connect` and `YellowstoneTpuSender::connect_with_callback` for more ease-of-use.

## Breaking

`Endpoints` is now embedded into `YellowstoneTpuSenderConfig` so it removes on parameters on every `create_yellowstone_tpu_sender_*` factory methods.


## Bugfix

`UpdateIdentity` future could never wake if the command-and-control channel between `TpuSenderIdentityUpdater` and `TpuSenderDriver` were to close with update identity command inflight.

# Jet changes

- Started the first draft of the `TpuDrain` to eventually replaced the entire `TransactionFanout`.
- Change endpoint address in configuration from String to `Url` to detect early, when booting the software if there is any misspell endpoint URL.
