### PR TITLE
feat(tpu-client): allow binding QUIC endpoints to a specific source address

### DIFF
--- a/apps/jet/config.yml
+++ b/apps/jet/config.yml
@@ -106,6 +106,13 @@ quic:
   endpoint_port_range:
     start: 35000
     end: 45000
+  # Local address the outbound QUIC endpoints bind to.
+  # Default is 0.0.0.0, which lets the kernel pick the source address.
+  # Set this when several jet instances share a host and each must source its traffic from
+  # its own public address -- unstaked peers are rate-limited by source IP by the validator,
+  # so one address per instance buys one connection/stream budget per instance.
+  # The address must already be configured on the host or startup fails.
+  # endpoint_bind_addr: 0.0.0.0
 
   # You can override the default TPU information for specific remote peers.
   # This will override any gossip information regarding tpu information of remote peers.

--- a/crates/tpu-client/src/config.rs
+++ b/crates/tpu-client/src/config.rs
@@ -3,7 +3,12 @@ use {
     serde::{Deserialize, Deserializer, de},
     solana_net_utils::{PortRange, VALIDATOR_PORT_RANGE},
     solana_pubkey::Pubkey,
-    std::{net::SocketAddr, num::NonZeroUsize, ops::Range, time::Duration},
+    std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        num::NonZeroUsize,
+        ops::Range,
+        time::Duration,
+    },
 };
 
 ///
@@ -80,6 +85,23 @@ pub struct TpuSenderConfig {
         default = "TpuSenderConfig::default_port_range"
     )]
     pub endpoint_port_range: PortRange,
+
+    ///
+    /// Local IP address to bind the QUIC endpoints to.
+    ///
+    /// Defaults to the wildcard address, which lets the kernel pick the source address
+    /// per destination -- the historical behavior.
+    ///
+    /// Set this to a specific address when running several instances on the same host and
+    /// each one must source its traffic from its own public address. Unstaked peers are
+    /// rate-limited by source IP by the agave validator, so a distinct source address per
+    /// instance buys a distinct connection and stream budget.
+    ///
+    /// The address must already be configured on the host; the endpoints fail to bind
+    /// otherwise and startup aborts.
+    ///
+    #[serde(default = "TpuSenderConfig::default_endpoint_bind_addr")]
+    pub endpoint_bind_addr: IpAddr,
 
     ///
     /// Maximum idle timeout for QUIC connections.
@@ -296,6 +318,10 @@ impl TpuSenderConfig {
     pub const fn default_port_range() -> PortRange {
         VALIDATOR_PORT_RANGE
     }
+
+    pub const fn default_endpoint_bind_addr() -> IpAddr {
+        DEFAULT_ENDPOINT_BIND_ADDR
+    }
 }
 
 ///
@@ -318,11 +344,13 @@ pub const DEFAULT_MAX_SEND_ATTEMPT: NonZeroUsize = NonZeroUsize::new(3).unwrap()
 pub const DEFAULT_REMOTE_PEER_ADDR_WATCH_INTERVAL: Duration = Duration::from_secs(5);
 pub const DEFAULT_TX_SEND_TIMEOUT: Duration = Duration::from_secs(2);
 pub const DEFAULT_LEADER_PREDICTION_LOOKAHEAD: NonZeroUsize = NonZeroUsize::new(4).unwrap();
+pub const DEFAULT_ENDPOINT_BIND_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
 
 impl Default for TpuSenderConfig {
     fn default() -> Self {
         Self {
             endpoint_port_range: VALIDATOR_PORT_RANGE,
+            endpoint_bind_addr: DEFAULT_ENDPOINT_BIND_ADDR,
             max_idle_timeout: QUIC_MAX_TIMEOUT,
             max_connection_attempts: DEFAULT_MAX_CONSECUTIVE_CONNECTION_ATTEMPT,
             transaction_sender_worker_channel_capacity: DEFAULT_PER_PEER_TRANSACTION_QUEUE_SIZE,
@@ -346,7 +374,10 @@ impl Default for TpuSenderConfig {
 pub mod test {
     use {
         crate::config::{TpuPortKind, TpuSenderConfig},
-        std::num::NonZeroUsize,
+        std::{
+            net::{IpAddr, Ipv4Addr},
+            num::NonZeroUsize,
+        },
     };
 
     #[test]
@@ -383,5 +414,23 @@ pub mod test {
 
         let config: super::TpuSenderConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config, expected);
+    }
+
+    #[test]
+    fn it_should_default_endpoint_bind_addr_to_wildcard() {
+        let config: TpuSenderConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(config.endpoint_bind_addr, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    }
+
+    #[test]
+    fn it_should_deser_endpoint_bind_addr() {
+        let yaml = r#"
+        endpoint_bind_addr: 63.254.172.225
+        "#;
+        let config: TpuSenderConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            config.endpoint_bind_addr,
+            IpAddr::V4(Ipv4Addr::new(63, 254, 172, 225))
+        );
     }
 }

--- a/crates/tpu-client/src/core.rs
+++ b/crates/tpu-client/src/core.rs
@@ -62,7 +62,7 @@ use {
         any::TypeId,
         collections::{BTreeMap, HashMap, HashSet, VecDeque},
         future,
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        net::SocketAddr,
         num::NonZeroUsize,
         pin::Pin,
         sync::{Arc, Mutex as StdMutex, atomic::AtomicU8},
@@ -3422,15 +3422,14 @@ impl TpuSenderDriverSpawner {
             key: private_key,
         });
 
+        let bind_addr = config.endpoint_bind_addr;
         let mut endpoints = vec![];
         for _ in 0..config.num_endpoints.get() {
             let endpoint = (0..config.max_local_port_binding_attempts)
                 .find_map(|_| {
-                    let (_, client_socket) = solana_net_utils::bind_in_range(
-                        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                        config.endpoint_port_range,
-                    )
-                    .ok()?;
+                    let (_, client_socket) =
+                        solana_net_utils::bind_in_range(bind_addr, config.endpoint_port_range)
+                            .ok()?;
                     Endpoint::new(
                         quinn::EndpointConfig::default(),
                         None,
@@ -3439,7 +3438,15 @@ impl TpuSenderDriverSpawner {
                     )
                     .ok()
                 })
-                .expect("Failed to create QUIC endpoint");
+                .unwrap_or_else(|| {
+                    // A non-wildcard bind address that is not configured on the host fails here
+                    // with EADDRNOTAVAIL. Abort rather than fall back to the wildcard, which
+                    // would silently source traffic from the host's primary address.
+                    panic!(
+                        "Failed to create QUIC endpoint bound to {bind_addr} in port range {:?} after {} attempts",
+                        config.endpoint_port_range, config.max_local_port_binding_attempts,
+                    )
+                });
 
             endpoints.push(endpoint);
         }


### PR DESCRIPTION
## Context

- agave keys unstaked peers by source IP in its connection table, so each source address carries its own connection budget.
- Jet's QUIC endpoints bind `0.0.0.0` regardless of Nomad networking — `host_network` only drives `listen_admin` / `listen_solana_like`. Co-located instances all source from the host's primary and share one budget and one port range.
- Staked peers key by pubkey, so this does not apply to them.

## Changes

- `endpoint_bind_addr` on `TpuSenderConfig`, defaulting to the wildcard.
- Passed to `bind_in_range` in place of the hardcoded `IpAddr::V4(Ipv4Addr::UNSPECIFIED)`.
- A bind failure aborts startup rather than falling back to the wildcard, which would source traffic from the host's primary and collapse every instance onto one budget.
- `apps/jet/config.yml` documents the key, commented out.

## Testing/Rollout

- `cargo test -p yellowstone-jet-tpu-client --lib config::` — 4 pass, including the wildcard default and explicit-address deserialization.
- `cargo fmt --check` and `cargo clippy -p yellowstone-jet-tpu-client --all-targets` clean.
- The wildcard default preserves current behaviour; no deployed config changes until a bind address is set.

Part of [PLA-904](https://linear.app/triton-one/issue/PLA-904/jet-scaling-add-secondary-ips-on-existing-teraswitch-nodes-nomad-per).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
