### PR TITLE
fix(jet): don't abort entire fanout on shield policy check error

### DIFF
--- a/apps/jet/src/transactions.rs
+++ b/apps/jet/src/transactions.rs
@@ -155,8 +155,6 @@ pub struct TransactionFanout<Rx, Tx> {
 enum SendTransactionError {
     #[error("transaction gateway sink is closed")]
     GatewayClosed,
-    #[error(transparent)]
-    ShieldPoliciesNotFound(#[from] CheckError),
 }
 
 pub trait TransactionPolicyStore {
@@ -251,9 +249,6 @@ where
                                         tracing::warn!("gateway sender is closed, stopping transaction fanout");
                                         return;
                                     },
-                                    SendTransactionError::ShieldPoliciesNotFound(_) => {
-                                        metrics::shield_policies_not_found_inc();
-                                    },
                                 }
                             }
                         },
@@ -298,10 +293,22 @@ where
         let txn_wire = tx.wire_transaction.clone();
 
         for (i, dest) in next_leaders.iter().enumerate() {
-            if !policy_store_service.is_allowed(&tx.policies, dest)? {
-                metrics::sts_tpu_denied_inc_by(1);
-                tracing::trace!("transaction {signature} is not allowed to be sent to {dest}");
-                continue;
+            match policy_store_service.is_allowed(&tx.policies, dest) {
+                Ok(true) => {}
+                Ok(false) => {
+                    metrics::sts_tpu_denied_inc_by(1);
+                    tracing::trace!("transaction {signature} is not allowed to be sent to {dest}");
+                    continue;
+                }
+                Err(error) => {
+                    // A policy store lookup failure must not abort forwarding to the
+                    // remaining leaders (or the extra_fwd pass below) for this transaction.
+                    metrics::shield_policies_not_found_inc();
+                    tracing::trace!(
+                        "transaction {signature} shield policy check failed for {dest}: {error}, skipping this leader"
+                    );
+                    continue;
+                }
             }
             sent_mask[i] = true;
             let txn_info = JetTxnInfo {

--- a/apps/jet/tests/test_transaction_fanout.rs
+++ b/apps/jet/tests/test_transaction_fanout.rs
@@ -180,6 +180,74 @@ async fn it_should_apply_shield_policies() {
 }
 
 #[tokio::test]
+async fn it_should_continue_fanout_after_policy_check_error() {
+    const FANOUT_FACTOR: usize = 3;
+    let (sink, source) = mpsc::unbounded();
+    let (gateway_tx, mut gateway_rx) = mpsc::channel(100);
+    let fake_schedule = FakeLeaderSchedule::default();
+
+    let extra_fanout_pubkeys = vec![Pubkey::new_unique()];
+
+    let my_schedule = vec![
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+    ];
+    fake_schedule.set_schedule(my_schedule.clone());
+
+    // Simulates a policy store that fails to find the policy account (e.g. not yet
+    // indexed) for the first leader, but works normally for the rest.
+    pub struct FlakyPolicy {
+        errors_on: Pubkey,
+    }
+
+    impl TransactionPolicyStore for FlakyPolicy {
+        fn is_allowed(&self, _policies: &[Pubkey], leader: &Pubkey) -> Result<bool, CheckError> {
+            if *leader == self.errors_on {
+                Err(CheckError::PolicyNotFound)
+            } else {
+                Ok(true)
+            }
+        }
+    }
+    let policy = FlakyPolicy {
+        errors_on: my_schedule[0],
+    };
+
+    #[allow(deprecated)]
+    let mut fanout = TransactionFanout::new(
+        Arc::new(fake_schedule),
+        Arc::new(policy),
+        source,
+        gateway_tx,
+        FanoutConfig::Custom(FANOUT_FACTOR),
+        extra_fanout_pubkeys.clone(),
+    );
+    let _fanout_jh = tokio::spawn(async move {
+        fanout.run().await;
+    });
+
+    let tx = create_send_transaction_request(Hash::new_unique());
+    sink.unbounded_send(tx.clone()).unwrap();
+
+    // Only my_schedule[0] errors out; the other two scheduled leaders plus the extra
+    // fanout target must still receive the transaction.
+    let expected_recipients = FANOUT_FACTOR - 1 + extra_fanout_pubkeys.len();
+    let mut actual_tx_sent = vec![];
+    for _i in 0..expected_recipients {
+        let actual_tx = gateway_rx.next().await.unwrap();
+        actual_tx_sent.push(actual_tx.remote_peer);
+    }
+
+    assert_eq!(actual_tx_sent.len(), expected_recipients);
+    assert!(!actual_tx_sent.contains(&my_schedule[0]));
+    assert!(actual_tx_sent.contains(&my_schedule[1]));
+    assert!(actual_tx_sent.contains(&my_schedule[2]));
+    assert!(actual_tx_sent.contains(&extra_fanout_pubkeys[0]));
+}
+
+#[tokio::test]
 async fn it_should_support_extra_fanout() {
     const FANOUT_FACTOR: usize = 3;
     let (sink, source) = mpsc::unbounded();


### PR DESCRIPTION
Problem: `TransactionFanout::fwd_tx` used `?` on the per-leader Shield policy check inside its `for` loop over the leader lookahead. A single `CheckError` from the policy store (for example, a policy account not present in the current snapshot) aborted the whole function immediately. This skipped every remaining leader in the fanout and the entire `extra_fwd` pass below it. Jet had already returned a signature to the client by this point, so the transaction silently never reached a validator. Production metrics confirm `shield_policies_not_found_total` incrementing so this codepath is being exercised.

Fix: match on `is_allowed()` per leader instead of using `?`. A `CheckError` now skips only that one leader, still increments `shield_policies_not_found_total`, and forwarding continues to the rest of the lookahead and to `extra_fwd` as before.