### PR TITLE
fix(jet): report 503 on /health when unable to forward any transaction

### DIFF
--- a/apps/jet/src/metrics.rs
+++ b/apps/jet/src/metrics.rs
@@ -90,8 +90,6 @@ pub mod jet {
             &["kind"]
         ).unwrap();
 
-        static ref ROOTED_TRANSACTIONS_POOL_SIZE: IntGauge = IntGauge::new("rooted_transactions_pool_size", "Total number of transactions in landed pool").unwrap();
-
         static ref STS_POOL_SIZE: IntGauge = IntGauge::new("sts_pool_size", "Number of transactions in the pool").unwrap();
         static ref STS_INFLIGHT_SIZE: IntGauge = IntGauge::new("sts_inflight_size", "Number of transactions sending right now").unwrap();
         static ref STS_RECEIVED_TOTAL: IntCounter = IntCounter::new("sts_received_total", "Total number of received transactions").unwrap();
@@ -252,7 +250,6 @@ pub mod jet {
             register!(GATEWAY_CONNECTED);
             register!(GRPC_SLOT_RECEIVED);
 
-            register!(ROOTED_TRANSACTIONS_POOL_SIZE);
             register!(SEND_TRANSACTION_ATTEMPT);
             register!(SEND_TRANSACTION_ERROR);
             register!(SEND_TRANSACTION_SUCCESS);
@@ -354,11 +351,6 @@ pub mod jet {
         );
 
         anyhow::ensure!(
-            ROOTED_TRANSACTIONS_POOL_SIZE.get() > 0,
-            "no transactions in the landing pool"
-        );
-
-        anyhow::ensure!(
             !yellowstone_jet_tpu_client::prom::forwarding_is_stalled(FORWARDING_STALL_THRESHOLD),
             "unable to forward any transaction in the last {:?}",
             FORWARDING_STALL_THRESHOLD
@@ -422,10 +414,6 @@ pub mod jet {
             .get()
             .try_into()
             .expect("failed to convert to u64")
-    }
-
-    pub fn rooted_transactions_pool_set_size(size: usize) {
-        ROOTED_TRANSACTIONS_POOL_SIZE.set(size as i64)
     }
 
     pub fn sts_pool_set_size(size: usize) {

--- a/apps/jet/src/metrics.rs
+++ b/apps/jet/src/metrics.rs
@@ -64,6 +64,11 @@ pub mod jet {
         std::{sync::Once, time::Duration},
     };
 
+    /// If jet has attempted to forward a transaction within this window and none of those
+    /// attempts succeeded, `/health` reports unhealthy so the load balancer takes it out of
+    /// rotation. An instance with nothing to forward is not affected.
+    const FORWARDING_STALL_THRESHOLD: Duration = Duration::from_secs(30);
+
     lazy_static::lazy_static! {
         static ref GRPC_SLOT_RECEIVED: IntGaugeVec = IntGaugeVec::new(
             Opts::new("grpc_slot_received", "Grpc slot by commitment"),
@@ -351,6 +356,12 @@ pub mod jet {
         anyhow::ensure!(
             ROOTED_TRANSACTIONS_POOL_SIZE.get() > 0,
             "no transactions in the landing pool"
+        );
+
+        anyhow::ensure!(
+            !yellowstone_jet_tpu_client::prom::forwarding_is_stalled(FORWARDING_STALL_THRESHOLD),
+            "unable to forward any transaction in the last {:?}",
+            FORWARDING_STALL_THRESHOLD
         );
 
         Ok(())

--- a/apps/jet/src/rpc.rs
+++ b/apps/jet/src/rpc.rs
@@ -76,22 +76,25 @@ impl RpcServer {
                             service,
                             uri: "/health",
                             get_response: move || {
-                                if let Some(expected) = allowed_identity {
-                                    let current =
-                                        jet_identity_updater.blocking_lock().get_identity();
-                                    if expected != current {
-                                        return ready((
-                                            StatusCode::SERVICE_UNAVAILABLE,
-                                            "identity mismatch".to_owned(),
-                                        ));
+                                let jet_identity_updater = Arc::clone(&jet_identity_updater);
+                                async move {
+                                    if let Some(expected) = allowed_identity {
+                                        let current =
+                                            jet_identity_updater.lock().await.get_identity();
+                                        if expected != current {
+                                            return (
+                                                StatusCode::SERVICE_UNAVAILABLE,
+                                                "identity mismatch".to_owned(),
+                                            );
+                                        }
                                     }
-                                }
 
-                                // TODO: need to check TPUs for processed?
-                                match crate::metrics::jet::get_health_status() {
-                                    Ok(()) => ready((StatusCode::OK, "ok".to_owned())),
-                                    Err(error) => {
-                                        ready((StatusCode::SERVICE_UNAVAILABLE, error.to_string()))
+                                    // TODO: need to check TPUs for processed?
+                                    match crate::metrics::jet::get_health_status() {
+                                        Ok(()) => (StatusCode::OK, "ok".to_owned()),
+                                        Err(error) => {
+                                            (StatusCode::SERVICE_UNAVAILABLE, error.to_string())
+                                        }
                                     }
                                 }
                             },

--- a/crates/tpu-client/src/prom.rs
+++ b/crates/tpu-client/src/prom.rs
@@ -4,7 +4,11 @@ use {
         Opts, Registry,
     },
     solana_pubkey::Pubkey,
-    std::{net::SocketAddr, time::Duration},
+    std::{
+        net::SocketAddr,
+        sync::atomic::{AtomicU64, Ordering},
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    },
 };
 
 lazy_static::lazy_static! {
@@ -170,6 +174,33 @@ lazy_static::lazy_static! {
     ).unwrap();
 }
 
+/// Milliseconds since `UNIX_EPOCH` of the last finalized send attempt (success or error), 0 = never.
+static LAST_SEND_ATTEMPT_MS: AtomicU64 = AtomicU64::new(0);
+/// Milliseconds since `UNIX_EPOCH` of the last successful send, 0 = never.
+static LAST_SEND_SUCCESS_MS: AtomicU64 = AtomicU64::new(0);
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// `true` when there have been send attempts within `stale_after` but none of them succeeded.
+/// An instance with no recent attempts (nothing to forward) is not considered stalled.
+pub fn forwarding_is_stalled(stale_after: Duration) -> bool {
+    let stale_after_ms = stale_after.as_millis() as u64;
+    let now = now_ms();
+
+    let last_attempt = LAST_SEND_ATTEMPT_MS.load(Ordering::Relaxed);
+    if last_attempt == 0 || now.saturating_sub(last_attempt) > stale_after_ms {
+        return false;
+    }
+
+    let last_success = LAST_SEND_SUCCESS_MS.load(Ordering::Relaxed);
+    last_success == 0 || now.saturating_sub(last_success) > stale_after_ms
+}
+
 pub fn incr_evicted_orphan_connections() {
     EVICTED_ORPHAN_CONNECTIONS.inc();
 }
@@ -212,6 +243,12 @@ pub fn incr_quic_gw_worker_tx_process_cnt(remote_peer: Pubkey, status: &str) {
     QUIC_GW_WORKER_TX_PROCESS_CNT
         .with_label_values(&[remote_peer.to_string().as_str(), status])
         .inc_by(1);
+
+    let now = now_ms();
+    LAST_SEND_ATTEMPT_MS.store(now, Ordering::Relaxed);
+    if status == "success" {
+        LAST_SEND_SUCCESS_MS.store(now, Ordering::Relaxed);
+    }
 }
 
 pub fn incr_quic_gw_drop_tx_cnt(leader: Pubkey, count: u64) {


### PR DESCRIPTION
Track the timestamp of the last finalized send attempt and the last successful send. `forwarding_is_stalled` reports true when there have been attempts within a 30s window but none of them succeeded. An instance with no recent attempts is not affected. `get_health_status` now includes this check.

Also replaced `blocking_lock()` with an async closure in the `/health` middleware, so it no longer panics on staked instances.